### PR TITLE
Add cstdint include

### DIFF
--- a/mavis/Field.h
+++ b/mavis/Field.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <array>
 #include <cassert>
+#include <cstdint>
 
 namespace mavis {
 


### PR DESCRIPTION
I was getting a compiler error with Clang on Ubuntu due to undefined standard types (`uint32_t` and so on). Adding this include fixes the problem.