### PR TITLE
Fix missing #include <cstdint> in DecoderTypes

### DIFF
--- a/mavis/DecoderTypes.h
+++ b/mavis/DecoderTypes.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <tuple>
 #include <string>
+#include<cstdint>
 
 namespace mavis {
 


### PR DESCRIPTION
This issue has been resolved by adding "#include<cstdint>" in the Decoder Types. I have tried to do the needful and the PR is now ready to merge