### PR TITLE
Rename ELFIO submodule to elfio

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "ELFIO"]
-	path = ELFIO
+[submodule "elfio"]
+	path = elfio
 	url = git@github.com:serge1/ELFIO.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include_directories(.)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/ELFIO)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/elfio)
 
 add_library(mavis
   impl/ExtractorRegistry.cpp


### PR DESCRIPTION
Mac file systems are case insensitive, so it's safer to only use lower case for directory names.