### PR TITLE
Process Expansion Instructions Last

### DIFF
--- a/impl/DTable.tcc
+++ b/impl/DTable.tcc
@@ -150,7 +150,13 @@ void DTable<InstType, AnnotationType, AnnotationTypeAllocator>::configure(const 
                     }
                     else
                     {
-                        expansions.emplace_back(std::bind(&DTable<InstType, AnnotationType, AnnotationTypeAllocator>::parseInstInfo_, this, jfile, inst, mnemonic, tags));
+                        expansions.emplace_back(std::bind(
+                            &DTable<InstType, AnnotationType, AnnotationTypeAllocator>::parseInstInfo_,
+                                                                                                  this,
+                                                                                                  jfile,
+                                                                                                  inst,
+                                                                                                  mnemonic,
+                                                                                                  tags));
                     }
                 } else if (!tags.isEmpty()) {
                     bool included = inclusions.isEmpty() || tags.matchAnyAny(inclusions);
@@ -163,7 +169,13 @@ void DTable<InstType, AnnotationType, AnnotationTypeAllocator>::configure(const 
                             }
                             else
                             {
-                                expansions.emplace_back(std::bind(&DTable<InstType, AnnotationType, AnnotationTypeAllocator>::parseInstInfo_, this, jfile, inst, mnemonic, tags));
+                                expansions.emplace_back(std::bind(
+                                    &DTable<InstType, AnnotationType, AnnotationTypeAllocator>::parseInstInfo_,
+                                                                                                          this,
+                                                                                                          jfile,
+                                                                                                          inst,
+                                                                                                          mnemonic,
+                                                                                                          tags));
                             }
                         }
                     }


### PR DESCRIPTION
Instruction expansion is used to support compressed instructions, so that they use the same factory as their non-compressed counterparts. When processing these instructions, the factory must already exist. This has been a bug in Mavis for a long time, but could be worked around by changing the order that the ISA JSONs were provided to Mavis.