### PR TITLE
ExtensionManager: Add allowlist/blocklist and enable/disable functionality

### DIFF
--- a/mavis/extension_managers/RISCVExtensionManager.hpp
+++ b/mavis/extension_managers/RISCVExtensionManager.hpp
@@ -422,16 +422,14 @@ namespace mavis::extension_manager::riscv
                 // Remove "rv" prefix
                 isa_view.remove_prefix(2);
 
-                ArchMap::iterator xlen_extension_it;
-
                 try
                 {
                     size_t num_chars = 0;
                     xlen_ = std::stoul(std::string(isa_view), &num_chars);
                     // Remove XLEN prefix
                     isa_view.remove_prefix(num_chars);
-                    xlen_extension_it = extensions_.find(xlen_);
-                    if(xlen_extension_it == extensions_.end())
+                    enabled_arch_ = extensions_.find(xlen_);
+                    if(enabled_arch_ == extensions_.end())
                     {
                         throw std::out_of_range("");
                     }
@@ -450,7 +448,7 @@ namespace mavis::extension_manager::riscv
                     throw InvalidISAStringException(isa_, "Missing base extension");
                 }
 
-                auto& xlen_extension = xlen_extension_it->second;
+                auto& xlen_extension = enabled_arch_->second;
                 const std::string base_isa(1, isa_view.front());
 
                 xlen_extension.enableBaseExtension(base_isa);

--- a/test/extensions/main.cpp
+++ b/test/extensions/main.cpp
@@ -1,25 +1,37 @@
 #include "mavis/extension_managers/RISCVExtensionManager.hpp"
 
-template<typename ExpectedExceptionType, bool is_elf = false>
-void testFailingISAString(const std::string& isa)
+template<typename ExpectedExceptionType, typename Callback>
+void testException(Callback&& callback)
 {
-    bool was_bad_isa_str = false;
+    bool saw_exception = false;
     try
     {
-        if constexpr(is_elf)
-        {
-            const auto rv_bad_isa_str = mavis::extension_manager::riscv::RISCVExtensionManager::fromELF(isa, "json/riscv_isa_spec.json", "json");
-        }
-        else
-        {
-            const auto rv_bad_isa_str = mavis::extension_manager::riscv::RISCVExtensionManager::fromISA(isa, "json/riscv_isa_spec.json", "json");
-        }
+        callback();
     }
     catch(const ExpectedExceptionType&)
     {
-        was_bad_isa_str = true;
+        saw_exception = true;
     }
-    assert(was_bad_isa_str);
+    assert(saw_exception);
+}
+
+template<bool is_elf>
+mavis::extension_manager::riscv::RISCVExtensionManager testISA(const std::string& isa)
+{
+    if constexpr(is_elf)
+    {
+        return mavis::extension_manager::riscv::RISCVExtensionManager::fromELF(isa, "json/riscv_isa_spec.json", "json");
+    }
+    else
+    {
+        return mavis::extension_manager::riscv::RISCVExtensionManager::fromISA(isa, "json/riscv_isa_spec.json", "json");
+    }
+}
+
+template<typename ExpectedExceptionType, bool is_elf = false>
+void testFailingISAString(const std::string& isa)
+{
+    testException<ExpectedExceptionType>([&isa](){ testISA<is_elf>(isa); });
 }
 
 int main(int argc, char* argv[])
@@ -73,6 +85,58 @@ int main(int argc, char* argv[])
     testFailingISAString<mavis::extension_manager::riscv::UnknownRISCVExtensionException>("rv64gc_zca_zclsd");
     testFailingISAString<mavis::extension_manager::riscv::InvalidBaseExtensionException>("rv32x");
     testFailingISAString<mavis::extension_manager::riscv::ISANotFoundInELFException, true>("hello_stripped");
+
+    {
+        // Test blocking an extension
+        auto man = mavis::extension_manager::riscv::RISCVExtensionManager::fromISASpecJSON("json/riscv_isa_spec.json", "json");
+        man.blockExtension("i");
+        testException<mavis::extension_manager::ExtensionNotAllowedException>([&man](){ man.setISA("rv64gcbv"); });
+    }
+
+    {
+        // Test blocking a meta extension
+        auto man = mavis::extension_manager::riscv::RISCVExtensionManager::fromISASpecJSON("json/riscv_isa_spec.json", "json");
+        man.blockExtension("g");
+        testException<mavis::extension_manager::ExtensionNotAllowedException>([&man](){ man.setISA("rv64i"); });
+    }
+
+    {
+        // Test extension allowlist
+        auto man = mavis::extension_manager::riscv::RISCVExtensionManager::fromISASpecJSON("json/riscv_isa_spec.json", "json");
+        man.allowExtension("g");
+        man.allowExtension("c");
+        man.allowExtension("b");
+        man.setISA("rv64gcb");
+        testException<mavis::extension_manager::ExtensionNotAllowedException>([&man](){ man.setISA("rv64imafdcbv"); });
+    }
+
+    {
+        // Test multiple ISA strings with an allowlist
+        auto man = mavis::extension_manager::riscv::RISCVExtensionManager::fromISASpecJSON("json/riscv_isa_spec.json", "json");
+        man.allowExtensions({"g", "c", "zicsr", "zifencei"});
+
+        const std::string isa_string = "rv64gc_zicsr_zifencei";
+        man.setISA(isa_string);
+        man.setISA(isa_string.substr(0, 6));
+        testException<mavis::extension_manager::ExtensionNotAllowedException>([&man](){ man.setISA("rv64gcb"); });
+        man.clearAllowedExtensions();
+        man.setISA("rv64gcb");
+    }
+
+    {
+        // Test disabling extension
+        auto man = mavis::extension_manager::riscv::RISCVExtensionManager::fromISA("rv64gc_zicsr_zifencei", "json/riscv_isa_spec.json", "json");
+        const auto orig_jsons = man.getJSONs();
+        man.disableExtension("d");
+        auto new_jsons = man.getJSONs();
+        assert(orig_jsons.size() == new_jsons.size() + 1);
+        man.enableExtension("d");
+        new_jsons = man.getJSONs();
+        assert(orig_jsons == new_jsons);
+        man.disableExtensions({"zicsr", "zifencei"});
+        new_jsons = man.getJSONs();
+        assert(orig_jsons.size() == new_jsons.size() + 2);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Fixes #37 

* Adds allowlist/blocklist functionality that generates an exception if `setISA` is called with an extension that is not allowed.
* Adds ability to enable/disable extensions after `setISA` has been called.