### PR TITLE
Enable more extensions for RV32

### DIFF
--- a/json/isa_rv32h.json
+++ b/json/isa_rv32h.json
@@ -1,0 +1,1 @@
+isa_rv64h.json

--- a/json/isa_rv32zfbfmin.json
+++ b/json/isa_rv32zfbfmin.json
@@ -1,0 +1,1 @@
+isa_rv64zfbfmin.json

--- a/json/isa_rv32zicbom.json
+++ b/json/isa_rv32zicbom.json
@@ -1,0 +1,1 @@
+isa_rv64zicbom.json

--- a/json/isa_rv32zicbop.json
+++ b/json/isa_rv32zicbop.json
@@ -1,0 +1,1 @@
+isa_rv64zicbop.json

--- a/json/isa_rv32zicboz.json
+++ b/json/isa_rv32zicboz.json
@@ -1,0 +1,1 @@
+isa_rv64zicboz.json

--- a/json/isa_rv32zihintntl.json
+++ b/json/isa_rv32zihintntl.json
@@ -1,0 +1,1 @@
+isa_rv64zihintntl.json

--- a/json/isa_rv32zvbb.json
+++ b/json/isa_rv32zvbb.json
@@ -1,0 +1,1 @@
+isa_rv64zvbb.json

--- a/json/isa_rv32zvbc.json
+++ b/json/isa_rv32zvbc.json
@@ -1,0 +1,1 @@
+isa_rv64zvbc.json

--- a/json/isa_rv32zvfbfwma.json
+++ b/json/isa_rv32zvfbfwma.json
@@ -1,0 +1,1 @@
+isa_rv64zvfbfwma.json

--- a/json/isa_rv32zvkg.json
+++ b/json/isa_rv32zvkg.json
@@ -1,0 +1,1 @@
+isa_rv64zvkg.json

--- a/json/isa_rv32zvkned.json
+++ b/json/isa_rv32zvkned.json
@@ -1,0 +1,1 @@
+isa_rv64zvkned.json

--- a/json/isa_rv32zvknh.json
+++ b/json/isa_rv32zvknh.json
@@ -1,0 +1,1 @@
+isa_rv64zvknh.json

--- a/json/isa_rv32zvksed.json
+++ b/json/isa_rv32zvksed.json
@@ -1,0 +1,1 @@
+isa_rv64zvksed.json

--- a/json/isa_rv32zvksh.json
+++ b/json/isa_rv32zvksh.json
@@ -1,0 +1,1 @@
+isa_rv64zvksh.json

--- a/json/riscv_isa_spec.json
+++ b/json/riscv_isa_spec.json
@@ -23,21 +23,21 @@
       "extension": "zce"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvkn",
       "meta_extension": ["zvknc", "zvkng"]
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvknc"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvks",
       "meta_extension": ["zvksc", "zvksg"]
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvksc"
     },
     {
@@ -52,31 +52,31 @@
   ],
   "config_extensions": [
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvl32b"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvl64b"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvl128b"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvl256b"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvl512b"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvl1024b"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvkt"
     },
     {
@@ -306,8 +306,9 @@
       "json": "isa_rv32zfa_h.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "h",
+      "requires": "i",
       "json": "isa_rv64h.json"
     },
     {
@@ -419,7 +420,7 @@
       "json": "isa_rv64zcb.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zfbfmin",
       "requires": ["f"],
       "json": "isa_rv64zfbfmin.json"
@@ -449,70 +450,70 @@
       "json": "isa_rv32zfhmin_d.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zicbom",
       "json": "isa_rv64zicbom.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zicbop",
       "json": "isa_rv64zicbop.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zicboz",
       "json": "isa_rv64zicboz.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zihintntl",
       "json": "isa_rv64zihintntl.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvbb",
       "meta_extension": ["zvkn", "zvks"],
       "json": "isa_rv64zvbb.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvbc",
       "meta_extension": ["zvknc", "zvksc"],
       "json": "isa_rv64zvbc.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvfbfwma",
       "requires": ["v"],
       "json": "isa_rv64zvfbfwma.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvkg",
       "meta_extension": ["zvkng", "zvksg"],
       "json": "isa_rv64zvkg.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvkned",
       "meta_extension": ["zvkn"],
       "json": "isa_rv64zvkned.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvknhb",
       "aliases": ["zvknha"],
       "meta_extension": ["zvkn"],
       "json": "isa_rv64zvknh.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvksed",
       "meta_extension": "zvks",
       "json": "isa_rv64zvksed.json"
     },
     {
-      "xlen": 64,
+      "xlen": [32, 64],
       "extension": "zvksh",
       "meta_extension": "zvks",
       "json": "isa_rv64zvksh.json"

--- a/json/riscv_isa_spec.json
+++ b/json/riscv_isa_spec.json
@@ -484,7 +484,7 @@
     {
       "xlen": [32, 64],
       "extension": "zvfbfwma",
-      "requires": ["v"],
+      "requires": ["v", "zfbfmin"],
       "json": "isa_rv64zvfbfwma.json"
     },
     {


### PR DESCRIPTION
Enable more extensions for RV32. Fixes failures in STF tools that try to use Mavis on RV32 traces.