### PR TITLE
Fixed boost json linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Mavis)
 set(CMAKE_CXX_STANDARD 17)
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-find_package (Boost 1.74.0 REQUIRED COMPONENTS program_options json)
+find_package (Boost 1.75.0 REQUIRED COMPONENTS program_options json)
 message (STATUS "Using BOOST ${Boost_VERSION_STRING}")
 
 include_directories(.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Mavis)
 set(CMAKE_CXX_STANDARD 17)
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-find_package (Boost 1.74.0 REQUIRED COMPONENTS program_options)
+find_package (Boost 1.74.0 REQUIRED COMPONENTS program_options json)
 message (STATUS "Using BOOST ${Boost_VERSION_STRING}")
 
 include_directories(.)

--- a/example/SimpleExample/CMakeLists.txt
+++ b/example/SimpleExample/CMakeLists.txt
@@ -4,4 +4,4 @@ add_executable(SimpleExample
     main.cpp
     )
 
-target_link_libraries(SimpleExample mavis boost_json)
+target_link_libraries(SimpleExample mavis Boost::json)

--- a/test/basic/CMakeLists.txt
+++ b/test/basic/CMakeLists.txt
@@ -26,4 +26,4 @@ file(CREATE_LINK ${CMAKE_SOURCE_DIR}/test/basic/golden.out ${CMAKE_CURRENT_BINAR
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 add_executable(Mavis main.cpp)
-target_link_libraries (Mavis mavis boost_json)
+target_link_libraries (Mavis mavis Boost::json)

--- a/test/directed/CMakeLists.txt
+++ b/test/directed/CMakeLists.txt
@@ -26,4 +26,4 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../basic)
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 add_executable(mavis_decode main.cpp)
 
-target_link_libraries (mavis_decode mavis Boost::program_options boost_json)
+target_link_libraries (mavis_decode mavis Boost::program_options Boost::json)

--- a/test/extensions/CMakeLists.txt
+++ b/test/extensions/CMakeLists.txt
@@ -26,4 +26,4 @@ file(CREATE_LINK ${CMAKE_SOURCE_DIR}/test/extensions/hello_stripped ${CMAKE_CURR
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 add_executable(ExtensionManager main.cpp)
-target_link_libraries (ExtensionManager mavis boost_json)
+target_link_libraries (ExtensionManager mavis Boost::json)

--- a/test/extensions/main.cpp
+++ b/test/extensions/main.cpp
@@ -6,6 +6,7 @@ template <typename ExpectedExceptionType, typename Callback>
 void testException(Callback && callback)
 {
     bool saw_exception = false;
+    (void) saw_exception;  // Needed for new compilers
     try
     {
         callback();


### PR DESCRIPTION
I was having compile issues because my boost installation is in non-standard path. This fixes the issue