### PR TITLE
Vector Bug Fixes for NF Special Field, vcpop.m and vfdot.vv

### DIFF
--- a/impl/forms/ExtractorForms.h
+++ b/impl/forms/ExtractorForms.h
@@ -3677,14 +3677,7 @@ namespace mavis
             {
                 // TODO: All forms should be using this pattern...
                 case SpecialField::VM:
-                    if (isMaskedField_(Form_V::idType::VM, fixed_field_mask_))
-                    {
-                        throw UnsupportedExtractorSpecialFieldID("VM", icode);
-                    }
-                    else
-                    {
-                        return extract_(Form_V::idType::VM, icode);
-                    }
+                    return extract_(Form_V::idType::VM, icode);
                 case SpecialField::RM:
                 case SpecialField::AQ:
                 case SpecialField::AVL:

--- a/json/isa_rv64zve32f.json
+++ b/json/isa_rv64zve32f.json
@@ -695,14 +695,5 @@
     "fixed": [ "rs1" ],
     "type": [ "vector", "float", "maskable" ],
     "v-oper": [ "rs2", "rd" ]
-  },
-  {
-    "mnemonic": "vfdot.vv",
-    "tags" : ["v"],
-    "form": "V",
-    "xform": "V_op",
-    "stencil": "0xe4001057",
-    "type": [ "vector", "float", "maskable" ],
-    "v-oper": "all"
   }
 ]

--- a/json/isa_rv64zve32x.json
+++ b/json/isa_rv64zve32x.json
@@ -1890,7 +1890,7 @@
     "v-oper": [ "rd" ]
   },
   {
-    "mnemonic": "vpopc.m",
+    "mnemonic": "vcpop.m",
     "tags" : ["v"],
     "form": "V",
     "stencil": "0x40082057",


### PR DESCRIPTION
- Made the NF field accessible for vector "whole register" instructions where the NF field is a fixed field (vs1r, vmv2r, vl4re8, etc.)
- Removed the vfdot.vv instruction which is no longer as part of the RVV extension
- Renamed `vpopc.m` to `vcpop.m` to align with RVV spec