### PR TITLE
Fixed zcd enablement

### DIFF
--- a/json/riscv_isa_spec.json
+++ b/json/riscv_isa_spec.json
@@ -140,7 +140,6 @@
     {
       "xlen": [32, 64],
       "extension": "zcd",
-      "enabled_by": [["c", "d"]],
       "requires": ["zca", "d"],
       "json": "isa_rv32zcd.json"
     },


### PR DESCRIPTION
zcd extension is not enabled by C nor D, but requires it.