### PR TITLE
Fixed field name maps; added special field STACK_ADJ for ZCMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/elfio ${Boost_INCLUDE_DIRS})
 add_library(mavis
   impl/ExtractorRegistry.cpp
   impl/FormRegistry.cpp
+  impl/InstMetaData.cpp
   impl/forms/CommonForms.cpp
   impl/forms/CompressedForms.cpp
   impl/forms/VectorForms.cpp

--- a/impl/DTable.tcc
+++ b/impl/DTable.tcc
@@ -48,7 +48,8 @@ namespace mavis
         ExtractorIF::PtrType override_extractor = nullptr;
         if (const auto it = inst.find("xform"); it != inst.end())
         {
-            override_extractor = extractors_.getExtractor(boost::json::value_to<std::string>(it->value()));
+            override_extractor =
+                extractors_.getExtractor(boost::json::value_to<std::string>(it->value()));
         }
 
         // Parse the factory name override, if present
@@ -71,8 +72,8 @@ namespace mavis
         if (const auto it = inst.find("overlay"); it != inst.end())
         {
             typename Overlay<InstType, AnnotationType>::PtrType olay =
-                std::make_shared<Overlay<InstType, AnnotationType>>(mnemonic, it->value().as_object(), inst,
-                                                                    override_extractor);
+                std::make_shared<Overlay<InstType, AnnotationType>>(
+                    mnemonic, it->value().as_object(), inst, override_extractor);
             builder_->buildOverlay(olay, jfile);
             // std::cout << *olay << std::endl;
             typename IFactory<InstType, AnnotationType>::PtrType ifact =
@@ -159,12 +160,12 @@ namespace mavis
         {
             const boost::json::value json = parseJSONWithException<BadISAFile>(jfile);
 
-            const auto& jobj = json.as_array();
+            const auto & jobj = json.as_array();
 
             // Read in the instructions JSON file and process fields that pertain to decoding...
             for (const auto & inst_value : jobj)
             {
-                const auto& inst = inst_value.as_object();
+                const auto & inst = inst_value.as_object();
 
                 std::string mnemonic;
                 if (const auto it = inst.find("mnemonic"); it != inst.end())
@@ -174,7 +175,8 @@ namespace mavis
                     MatchSet<Tag> tags;
                     if (const auto tag_it = inst.find("tags"); tag_it != inst.end())
                     {
-                        tags = MatchSet<Tag>(boost::json::value_to<std::vector<std::string>>(tag_it->value()));
+                        tags = MatchSet<Tag>(
+                            boost::json::value_to<std::vector<std::string>>(tag_it->value()));
                     }
 
                     const bool is_expansion = inst.find("expand") != inst.end();
@@ -228,7 +230,8 @@ namespace mavis
                     // to help the poor user find where he's missing a mnemonic
                     if (const auto stencil_it = inst.find("stencil"); stencil_it != inst.end())
                     {
-                        throw BuildErrorMissingMnemonic(jfile, boost::json::value_to<std::string>(stencil_it->value()));
+                        throw BuildErrorMissingMnemonic(
+                            jfile, boost::json::value_to<std::string>(stencil_it->value()));
                     }
                     throw BuildErrorMissingMnemonic(jfile);
                 }

--- a/impl/InstMetaData.cpp
+++ b/impl/InstMetaData.cpp
@@ -1,0 +1,366 @@
+
+#include <string>
+#include <iostream>
+#include <boost/bimap.hpp>
+
+#include "mavis/InstMetaData.h"
+
+namespace mavis
+{
+
+    template <class BmType>
+    BmType make_bimap(std::initializer_list<typename BmType::value_type> list)
+    {
+        return BmType(list.begin(), list.end());
+    }
+
+    using BmInstMapType = boost::bimap<std::string, InstMetaData::InstructionTypes>;
+    static const BmInstMapType tmap = make_bimap<BmInstMapType>({
+            {"int",               InstMetaData::InstructionTypes::INT              },
+            {"float",             InstMetaData::InstructionTypes::FLOAT            },
+            {"arith",             InstMetaData::InstructionTypes::ARITH            },
+            {"mul",               InstMetaData::InstructionTypes::MULTIPLY         },
+            {"div",               InstMetaData::InstructionTypes::DIVIDE           },
+            {"branch",            InstMetaData::InstructionTypes::BRANCH           },
+            {"pc",                InstMetaData::InstructionTypes::PC               },
+            {"cond",              InstMetaData::InstructionTypes::CONDITIONAL      },
+            {"jal",               InstMetaData::InstructionTypes::JAL              },
+            {"jalr",              InstMetaData::InstructionTypes::JALR             },
+            {"load",              InstMetaData::InstructionTypes::LOAD             },
+            {"store",             InstMetaData::InstructionTypes::STORE            },
+            {"mac",               InstMetaData::InstructionTypes::MAC              },
+            {"sqrt",              InstMetaData::InstructionTypes::SQRT             },
+            {"convert",           InstMetaData::InstructionTypes::CONVERT          },
+            {"compare",           InstMetaData::InstructionTypes::COMPARE          },
+            {"move",              InstMetaData::InstructionTypes::MOVE             },
+            {"classify",          InstMetaData::InstructionTypes::CLASSIFY         },
+            {"vector",            InstMetaData::InstructionTypes::VECTOR           },
+            {"maskable",          InstMetaData::InstructionTypes::MASKABLE         },
+            {"unit_stride",       InstMetaData::InstructionTypes::UNIT_STRIDE      },
+            {"stride",            InstMetaData::InstructionTypes::STRIDE           },
+            {"ordered_indexed",   InstMetaData::InstructionTypes::ORDERED_INDEXED  },
+            {"unordered_indexed", InstMetaData::InstructionTypes::UNORDERED_INDEXED},
+            {"segment",           InstMetaData::InstructionTypes::SEGMENT          },
+            {"faultfirst",        InstMetaData::InstructionTypes::FAULTFIRST       },
+            {"whole",             InstMetaData::InstructionTypes::WHOLE            },
+            {"mask",              InstMetaData::InstructionTypes::MASK             },
+            {"widening",          InstMetaData::InstructionTypes::WIDENING         },
+            {"hypervisor",        InstMetaData::InstructionTypes::HYPERVISOR       },
+            {"crypto",            InstMetaData::InstructionTypes::CRYPTO           },
+            {"prefetch",          InstMetaData::InstructionTypes::PREFETCH         },
+            {"ntl",               InstMetaData::InstructionTypes::NTL              },
+            {"hint",              InstMetaData::InstructionTypes::HINT             },
+            {"cache",             InstMetaData::InstructionTypes::CACHE            },
+            {"atomic",            InstMetaData::InstructionTypes::ATOMIC           },
+            {"fence",             InstMetaData::InstructionTypes::FENCE            },
+            {"system",            InstMetaData::InstructionTypes::SYSTEM           },
+            {"csr",               InstMetaData::InstructionTypes::CSR              }
+        });
+
+    using ISAExtenMapType = boost::bimap<std::string, InstMetaData::ISAExtensionIndex>;
+    static const ISAExtenMapType isamap = make_bimap<ISAExtenMapType>({
+            {"A", InstMetaData::ISAExtensionIndex::A},
+            {"B", InstMetaData::ISAExtensionIndex::B},
+            {"C", InstMetaData::ISAExtensionIndex::C},
+            {"D", InstMetaData::ISAExtensionIndex::D},
+            {"F", InstMetaData::ISAExtensionIndex::F},
+            {"G", InstMetaData::ISAExtensionIndex::G},
+            {"H", InstMetaData::ISAExtensionIndex::H},
+            {"I", InstMetaData::ISAExtensionIndex::I},
+            {"M", InstMetaData::ISAExtensionIndex::M},
+            {"Q", InstMetaData::ISAExtensionIndex::Q},
+            {"V", InstMetaData::ISAExtensionIndex::V}
+        });
+
+    using OpFieldIDMapType = boost::bimap<std::string, InstMetaData::OperandFieldID>;
+    static const OpFieldIDMapType ofimap = make_bimap<OpFieldIDMapType>({
+            {"rs1",        InstMetaData::OperandFieldID::RS1},
+            {"rs2",        InstMetaData::OperandFieldID::RS2},
+            {"rs3",        InstMetaData::OperandFieldID::RS3},
+            {"rs4",        InstMetaData::OperandFieldID::RS4},
+            {"rs_max",     InstMetaData::OperandFieldID::RS_MAX},
+            {"fused_sd_0", InstMetaData::OperandFieldID::FUSED_SD_0},
+            {"fused_sd_1", InstMetaData::OperandFieldID::FUSED_SD_1},
+            {"temp_rs1",   InstMetaData::OperandFieldID::TEMP_RS1},
+            {"temp_rs2",   InstMetaData::OperandFieldID::TEMP_RS2},
+            {"temp_rs3",   InstMetaData::OperandFieldID::TEMP_RS3},
+            {"push_rs1",   InstMetaData::OperandFieldID::PUSH_RS1},
+            {"push_rs2",   InstMetaData::OperandFieldID::PUSH_RS2},
+            {"push_rs3",   InstMetaData::OperandFieldID::PUSH_RS3},
+            {"push_rs4",   InstMetaData::OperandFieldID::PUSH_RS4},
+            {"push_rs5",   InstMetaData::OperandFieldID::PUSH_RS5},
+            {"push_rs6",   InstMetaData::OperandFieldID::PUSH_RS6},
+            {"push_rs7",   InstMetaData::OperandFieldID::PUSH_RS7},
+            {"push_rs8",   InstMetaData::OperandFieldID::PUSH_RS8},
+            {"push_rs9",   InstMetaData::OperandFieldID::PUSH_RS9},
+            {"push_rs10",  InstMetaData::OperandFieldID::PUSH_RS10},
+            {"push_rs11",  InstMetaData::OperandFieldID::PUSH_RS11},
+            {"push_rs12",  InstMetaData::OperandFieldID::PUSH_RS12},
+            {"push_rs13",  InstMetaData::OperandFieldID::PUSH_RS13},
+            {"rd",         InstMetaData::OperandFieldID::RD},
+            {"rd1",        InstMetaData::OperandFieldID::RD1},
+            {"rd2",        InstMetaData::OperandFieldID::RD2},
+            {"rd_max",     InstMetaData::OperandFieldID::RD_MAX},
+            {"fused_rd_0", InstMetaData::OperandFieldID::FUSED_RD_0},
+            {"fused_rd_1", InstMetaData::OperandFieldID::FUSED_RD_1},
+            {"temp_rd",    InstMetaData::OperandFieldID::TEMP_RD},
+            {"temp_rd2",   InstMetaData::OperandFieldID::TEMP_RD2},
+            {"pop_rd1",    InstMetaData::OperandFieldID::POP_RD1},
+            {"pop_rd2",    InstMetaData::OperandFieldID::POP_RD2},
+            {"pop_rd3",    InstMetaData::OperandFieldID::POP_RD3},
+            {"pop_rd4",    InstMetaData::OperandFieldID::POP_RD4},
+            {"pop_rd5",    InstMetaData::OperandFieldID::POP_RD5},
+            {"pop_rd6",    InstMetaData::OperandFieldID::POP_RD6},
+            {"pop_rd7",    InstMetaData::OperandFieldID::POP_RD7},
+            {"pop_rd8",    InstMetaData::OperandFieldID::POP_RD8},
+            {"pop_rd9",    InstMetaData::OperandFieldID::POP_RD9},
+            {"pop_rd10",   InstMetaData::OperandFieldID::POP_RD10},
+            {"pop_rd11",   InstMetaData::OperandFieldID::POP_RD11},
+            {"pop_rd12",   InstMetaData::OperandFieldID::POP_RD12},
+            {"pop_rd13",   InstMetaData::OperandFieldID::POP_RD13},
+        });
+
+    /**
+     * Construct from JSON information pertaining to extraction
+     */
+    InstMetaData::InstMetaData(const json & inst, bool compressed,
+                               const MatchSet<Tag> & tags) :
+        compressed_(compressed),
+        tags_(tags)
+    {
+
+        if (ofimap.size() != size_t(OperandFieldID::__N)) {
+            std::cerr << "MAVIS: ofimap size is not the same as the OperandFieldID enum class"
+                      << "\n\tUpdate the map in " << __FILE__ << std::endl;
+            exit(-1);
+        }
+
+        if (isamap.size() != size_t(ISAExtensionIndex::__N)) {
+            std::cerr << "MAVIS: isamap size is not the same as the ISAExtensionIndex enum class"
+                      << "\n\tUpdate the map in " << __FILE__ << std::endl;
+            exit(-1);
+        }
+
+        oper_type_.fill(InstMetaData::OperandTypes::NONE);
+
+        // Type
+        parseTypeStanza_(inst);
+
+        // Data size
+        parseDataSizeStanza_(inst);
+
+        // Word operand types
+        if (const auto it = inst.find("w-oper"); it != inst.end())
+        {
+            const auto& it_value = it->value();
+            if (it_value == "all")
+            {
+                setAllOperandsType_(OperandTypes::WORD);
+            }
+            else
+            {
+                FieldNameListType flist;
+                flist = boost::json::value_to<FieldNameListType>(it_value);
+                setOperandsType_(flist, OperandTypes::WORD);
+            }
+        }
+
+        // Long operand types
+        if (const auto it = inst.find("l-oper"); it != inst.end())
+        {
+            const auto& it_value = it->value();
+            if (it_value == "all")
+            {
+                setAllOperandsType_(OperandTypes::LONG);
+            }
+            else
+            {
+                FieldNameListType flist;
+                flist = boost::json::value_to<FieldNameListType>(it_value);
+                setOperandsType_(flist, OperandTypes::LONG);
+            }
+        }
+
+        // Single operand types
+        if (const auto it = inst.find("s-oper"); it != inst.end())
+        {
+            const auto& it_value = it->value();
+            if (it_value == "all")
+            {
+                setAllOperandsType_(OperandTypes::SINGLE);
+            }
+            else
+            {
+                FieldNameListType flist;
+                flist = boost::json::value_to<FieldNameListType>(it_value);
+                setOperandsType_(flist, OperandTypes::SINGLE);
+            }
+        }
+
+        // Double operand types
+        if (const auto it = inst.find("d-oper"); it != inst.end())
+        {
+            const auto& it_value = it->value();
+            if (it_value == "all")
+            {
+                setAllOperandsType_(OperandTypes::DOUBLE);
+            }
+            else
+            {
+                FieldNameListType flist;
+                flist = boost::json::value_to<FieldNameListType>(it_value);
+                setOperandsType_(flist, OperandTypes::DOUBLE);
+            }
+        }
+
+        // Quad operand types
+        if (const auto it = inst.find("q-oper"); it != inst.end())
+        {
+            const auto& it_value = it->value();
+            if (it_value == "all")
+            {
+                setAllOperandsType_(OperandTypes::QUAD);
+            }
+            else
+            {
+                FieldNameListType flist;
+                flist = boost::json::value_to<FieldNameListType>(it_value);
+                setOperandsType_(flist, OperandTypes::QUAD);
+            }
+        }
+
+        // Vector operand types
+        if (const auto it = inst.find("v-oper"); it != inst.end())
+        {
+            const auto& it_value = it->value();
+            if (it_value == "all")
+            {
+                setAllOperandsType_(OperandTypes::VECTOR);
+            }
+            else
+            {
+                FieldNameListType flist;
+                flist = boost::json::value_to<FieldNameListType>(it_value);
+                setOperandsType_(flist, OperandTypes::VECTOR);
+            }
+        }
+
+        // Try to find ISA extensions of the form 'wX' where 'w' is a an optional
+        // "width" (e.g. 32, 64, etc.) and 'X' is an extension letter
+        if (const auto it = inst.find("isa"); it != inst.end())
+        {
+            ISAExtListType ilist = boost::json::value_to<ISAExtListType>(it->value());
+            if (!ilist.empty())
+            {
+                std::smatch matches;
+                for (const auto & s : ilist)
+                {
+                    // matches[0] is the entire string matched,
+                    // matches[1] is the capture group for the optional width (emtpy if not
+                    // provided) matches[2] is the capture group for the ISA extension letter
+                    if (std::regex_search(s, matches, isa_ext_pattern_))
+                    {
+                        const auto itr = isamap.left.find(matches[2].str());
+                        if (itr != isamap.left.end())
+                        {
+                            isa_ext_ |=
+                                (1ull << static_cast<std::underlying_type_t<ISAExtensionIndex>>(
+                                    itr->second));
+                        }
+                        else
+                        {
+                            // Invalid ISA extension letter
+                            throw BuildErrorInvalidISAExtension(boost::json::value_to<std::string>(inst.at("mnemonic")), s,
+                                                                matches[2].str());
+                        }
+                        if (matches[1].length() != 0)
+                        {
+                            const uint32_t n =
+                                std::strtoull(matches[1].str().c_str(), nullptr, 0);
+                            if ((n == 0) || ((n & (n - 1)) != 0))
+                            {
+                                // Not a non-zero power of 2
+                                throw BuildErrorInvalidISAWidth(boost::json::value_to<std::string>(inst.at("mnemonic")), s, n);
+                            }
+                            setISAWidth(itr->second, n);
+                        }
+                    }
+                    else
+                    {
+                        // Malformed ISA extension string
+                        throw BuildErrorMalformedISAExtension(boost::json::value_to<std::string>(inst.at("mnemonic")), s);
+                    }
+                }
+            }
+        }
+    }
+
+    void InstMetaData::parseTypeStanza_(const json & inst)
+    {
+        // Merge type information from the overlay instruction and the base
+        if (const auto it = inst.find("type"); it != inst.end())
+        {
+            const FieldNameListType tlist = boost::json::value_to<FieldNameListType>(it->value());
+            for (const auto & t : tlist)
+            {
+                const auto itr = tmap.left.find(t);
+                if (itr == tmap.left.end())
+                {
+                    throw BuildErrorUnknownType(boost::json::value_to<std::string>(inst.at("mnemonic")), t);
+                }
+                inst_types_ |=
+                    static_cast<std::underlying_type_t<InstructionTypes>>(itr->second);
+            }
+        }
+    }
+
+    void InstMetaData::parseDataSizeStanza_(const json & inst)
+    {
+        // Merge data size information from the overlay instruction and the base
+        if (const auto it = inst.find("data"); it != inst.end())
+        {
+            data_size_ = boost::json::value_to<uint32_t>(it->value());
+            // Check positive, power-of-2 or zero
+            if ((data_size_ & (data_size_ - 1)) || (int32_t(data_size_) < 0))
+            {
+                throw BuildErrorInvalidDataSize(boost::json::value_to<std::string>(inst.at("mnemonic")), data_size_);
+            }
+        }
+    }
+
+    std::underlying_type_t<InstMetaData::OperandFieldID> InstMetaData::getFieldIndex_(const std::string & fname)
+    {
+        const auto itr = ofimap.left.find(fname);
+        if (itr == ofimap.left.end())
+        {
+            throw BuildErrorUnknownFormField("InstMetaData", fname);
+        }
+        return static_cast<std::underlying_type_t<OperandFieldID>>(itr->second);
+    }
+
+    std::string InstMetaData::getInstructionTypeName(const InstructionTypes & inst_type)
+    {
+        return tmap.right.at(inst_type);
+    }
+
+    const std::string & InstMetaData::getFieldIDName(OperandFieldID fid)
+    {
+        return ofimap.right.at(fid);
+    }
+
+    InstMetaData::OperandFieldID InstMetaData::getFieldID(const std::string & fname)
+    {
+        const auto itr = ofimap.left.find(fname);
+        if (itr == ofimap.left.end())
+        {
+            return OperandFieldID::NONE;
+        }
+        return itr->second;
+    }
+
+    // InstMetaData types
+    const std::regex InstMetaData::isa_ext_pattern_ =
+        std::regex("([1-9][0-9]*?)?([A-Z])", std::regex::optimize);
+
+
+}

--- a/impl/InstMetaData.cpp
+++ b/impl/InstMetaData.cpp
@@ -16,126 +16,127 @@ namespace mavis
 
     using BmInstMapType = boost::bimap<std::string, InstMetaData::InstructionTypes>;
     static const BmInstMapType tmap = make_bimap<BmInstMapType>({
-            {"int",               InstMetaData::InstructionTypes::INT              },
-            {"float",             InstMetaData::InstructionTypes::FLOAT            },
-            {"arith",             InstMetaData::InstructionTypes::ARITH            },
-            {"mul",               InstMetaData::InstructionTypes::MULTIPLY         },
-            {"div",               InstMetaData::InstructionTypes::DIVIDE           },
-            {"branch",            InstMetaData::InstructionTypes::BRANCH           },
-            {"pc",                InstMetaData::InstructionTypes::PC               },
-            {"cond",              InstMetaData::InstructionTypes::CONDITIONAL      },
-            {"jal",               InstMetaData::InstructionTypes::JAL              },
-            {"jalr",              InstMetaData::InstructionTypes::JALR             },
-            {"load",              InstMetaData::InstructionTypes::LOAD             },
-            {"store",             InstMetaData::InstructionTypes::STORE            },
-            {"mac",               InstMetaData::InstructionTypes::MAC              },
-            {"sqrt",              InstMetaData::InstructionTypes::SQRT             },
-            {"convert",           InstMetaData::InstructionTypes::CONVERT          },
-            {"compare",           InstMetaData::InstructionTypes::COMPARE          },
-            {"move",              InstMetaData::InstructionTypes::MOVE             },
-            {"classify",          InstMetaData::InstructionTypes::CLASSIFY         },
-            {"vector",            InstMetaData::InstructionTypes::VECTOR           },
-            {"maskable",          InstMetaData::InstructionTypes::MASKABLE         },
-            {"unit_stride",       InstMetaData::InstructionTypes::UNIT_STRIDE      },
-            {"stride",            InstMetaData::InstructionTypes::STRIDE           },
-            {"ordered_indexed",   InstMetaData::InstructionTypes::ORDERED_INDEXED  },
-            {"unordered_indexed", InstMetaData::InstructionTypes::UNORDERED_INDEXED},
-            {"segment",           InstMetaData::InstructionTypes::SEGMENT          },
-            {"faultfirst",        InstMetaData::InstructionTypes::FAULTFIRST       },
-            {"whole",             InstMetaData::InstructionTypes::WHOLE            },
-            {"mask",              InstMetaData::InstructionTypes::MASK             },
-            {"widening",          InstMetaData::InstructionTypes::WIDENING         },
-            {"hypervisor",        InstMetaData::InstructionTypes::HYPERVISOR       },
-            {"crypto",            InstMetaData::InstructionTypes::CRYPTO           },
-            {"prefetch",          InstMetaData::InstructionTypes::PREFETCH         },
-            {"ntl",               InstMetaData::InstructionTypes::NTL              },
-            {"hint",              InstMetaData::InstructionTypes::HINT             },
-            {"cache",             InstMetaData::InstructionTypes::CACHE            },
-            {"atomic",            InstMetaData::InstructionTypes::ATOMIC           },
-            {"fence",             InstMetaData::InstructionTypes::FENCE            },
-            {"system",            InstMetaData::InstructionTypes::SYSTEM           },
-            {"csr",               InstMetaData::InstructionTypes::CSR              }
-        });
+        {"int",               InstMetaData::InstructionTypes::INT              },
+        {"float",             InstMetaData::InstructionTypes::FLOAT            },
+        {"arith",             InstMetaData::InstructionTypes::ARITH            },
+        {"mul",               InstMetaData::InstructionTypes::MULTIPLY         },
+        {"div",               InstMetaData::InstructionTypes::DIVIDE           },
+        {"branch",            InstMetaData::InstructionTypes::BRANCH           },
+        {"pc",                InstMetaData::InstructionTypes::PC               },
+        {"cond",              InstMetaData::InstructionTypes::CONDITIONAL      },
+        {"jal",               InstMetaData::InstructionTypes::JAL              },
+        {"jalr",              InstMetaData::InstructionTypes::JALR             },
+        {"load",              InstMetaData::InstructionTypes::LOAD             },
+        {"store",             InstMetaData::InstructionTypes::STORE            },
+        {"mac",               InstMetaData::InstructionTypes::MAC              },
+        {"sqrt",              InstMetaData::InstructionTypes::SQRT             },
+        {"convert",           InstMetaData::InstructionTypes::CONVERT          },
+        {"compare",           InstMetaData::InstructionTypes::COMPARE          },
+        {"move",              InstMetaData::InstructionTypes::MOVE             },
+        {"classify",          InstMetaData::InstructionTypes::CLASSIFY         },
+        {"vector",            InstMetaData::InstructionTypes::VECTOR           },
+        {"maskable",          InstMetaData::InstructionTypes::MASKABLE         },
+        {"unit_stride",       InstMetaData::InstructionTypes::UNIT_STRIDE      },
+        {"stride",            InstMetaData::InstructionTypes::STRIDE           },
+        {"ordered_indexed",   InstMetaData::InstructionTypes::ORDERED_INDEXED  },
+        {"unordered_indexed", InstMetaData::InstructionTypes::UNORDERED_INDEXED},
+        {"segment",           InstMetaData::InstructionTypes::SEGMENT          },
+        {"faultfirst",        InstMetaData::InstructionTypes::FAULTFIRST       },
+        {"whole",             InstMetaData::InstructionTypes::WHOLE            },
+        {"mask",              InstMetaData::InstructionTypes::MASK             },
+        {"widening",          InstMetaData::InstructionTypes::WIDENING         },
+        {"hypervisor",        InstMetaData::InstructionTypes::HYPERVISOR       },
+        {"crypto",            InstMetaData::InstructionTypes::CRYPTO           },
+        {"prefetch",          InstMetaData::InstructionTypes::PREFETCH         },
+        {"ntl",               InstMetaData::InstructionTypes::NTL              },
+        {"hint",              InstMetaData::InstructionTypes::HINT             },
+        {"cache",             InstMetaData::InstructionTypes::CACHE            },
+        {"atomic",            InstMetaData::InstructionTypes::ATOMIC           },
+        {"fence",             InstMetaData::InstructionTypes::FENCE            },
+        {"system",            InstMetaData::InstructionTypes::SYSTEM           },
+        {"csr",               InstMetaData::InstructionTypes::CSR              }
+    });
 
     using ISAExtenMapType = boost::bimap<std::string, InstMetaData::ISAExtensionIndex>;
     static const ISAExtenMapType isamap = make_bimap<ISAExtenMapType>({
-            {"A", InstMetaData::ISAExtensionIndex::A},
-            {"B", InstMetaData::ISAExtensionIndex::B},
-            {"C", InstMetaData::ISAExtensionIndex::C},
-            {"D", InstMetaData::ISAExtensionIndex::D},
-            {"F", InstMetaData::ISAExtensionIndex::F},
-            {"G", InstMetaData::ISAExtensionIndex::G},
-            {"H", InstMetaData::ISAExtensionIndex::H},
-            {"I", InstMetaData::ISAExtensionIndex::I},
-            {"M", InstMetaData::ISAExtensionIndex::M},
-            {"Q", InstMetaData::ISAExtensionIndex::Q},
-            {"V", InstMetaData::ISAExtensionIndex::V}
-        });
+        {"A", InstMetaData::ISAExtensionIndex::A},
+        {"B", InstMetaData::ISAExtensionIndex::B},
+        {"C", InstMetaData::ISAExtensionIndex::C},
+        {"D", InstMetaData::ISAExtensionIndex::D},
+        {"F", InstMetaData::ISAExtensionIndex::F},
+        {"G", InstMetaData::ISAExtensionIndex::G},
+        {"H", InstMetaData::ISAExtensionIndex::H},
+        {"I", InstMetaData::ISAExtensionIndex::I},
+        {"M", InstMetaData::ISAExtensionIndex::M},
+        {"Q", InstMetaData::ISAExtensionIndex::Q},
+        {"V", InstMetaData::ISAExtensionIndex::V}
+    });
 
     using OpFieldIDMapType = boost::bimap<std::string, InstMetaData::OperandFieldID>;
     static const OpFieldIDMapType ofimap = make_bimap<OpFieldIDMapType>({
-            {"rs1",        InstMetaData::OperandFieldID::RS1},
-            {"rs2",        InstMetaData::OperandFieldID::RS2},
-            {"rs3",        InstMetaData::OperandFieldID::RS3},
-            {"rs4",        InstMetaData::OperandFieldID::RS4},
-            {"rs_max",     InstMetaData::OperandFieldID::RS_MAX},
-            {"fused_sd_0", InstMetaData::OperandFieldID::FUSED_SD_0},
-            {"fused_sd_1", InstMetaData::OperandFieldID::FUSED_SD_1},
-            {"temp_rs1",   InstMetaData::OperandFieldID::TEMP_RS1},
-            {"temp_rs2",   InstMetaData::OperandFieldID::TEMP_RS2},
-            {"temp_rs3",   InstMetaData::OperandFieldID::TEMP_RS3},
-            {"push_rs1",   InstMetaData::OperandFieldID::PUSH_RS1},
-            {"push_rs2",   InstMetaData::OperandFieldID::PUSH_RS2},
-            {"push_rs3",   InstMetaData::OperandFieldID::PUSH_RS3},
-            {"push_rs4",   InstMetaData::OperandFieldID::PUSH_RS4},
-            {"push_rs5",   InstMetaData::OperandFieldID::PUSH_RS5},
-            {"push_rs6",   InstMetaData::OperandFieldID::PUSH_RS6},
-            {"push_rs7",   InstMetaData::OperandFieldID::PUSH_RS7},
-            {"push_rs8",   InstMetaData::OperandFieldID::PUSH_RS8},
-            {"push_rs9",   InstMetaData::OperandFieldID::PUSH_RS9},
-            {"push_rs10",  InstMetaData::OperandFieldID::PUSH_RS10},
-            {"push_rs11",  InstMetaData::OperandFieldID::PUSH_RS11},
-            {"push_rs12",  InstMetaData::OperandFieldID::PUSH_RS12},
-            {"push_rs13",  InstMetaData::OperandFieldID::PUSH_RS13},
-            {"rd",         InstMetaData::OperandFieldID::RD},
-            {"rd1",        InstMetaData::OperandFieldID::RD1},
-            {"rd2",        InstMetaData::OperandFieldID::RD2},
-            {"rd_max",     InstMetaData::OperandFieldID::RD_MAX},
-            {"fused_rd_0", InstMetaData::OperandFieldID::FUSED_RD_0},
-            {"fused_rd_1", InstMetaData::OperandFieldID::FUSED_RD_1},
-            {"temp_rd",    InstMetaData::OperandFieldID::TEMP_RD},
-            {"temp_rd2",   InstMetaData::OperandFieldID::TEMP_RD2},
-            {"pop_rd1",    InstMetaData::OperandFieldID::POP_RD1},
-            {"pop_rd2",    InstMetaData::OperandFieldID::POP_RD2},
-            {"pop_rd3",    InstMetaData::OperandFieldID::POP_RD3},
-            {"pop_rd4",    InstMetaData::OperandFieldID::POP_RD4},
-            {"pop_rd5",    InstMetaData::OperandFieldID::POP_RD5},
-            {"pop_rd6",    InstMetaData::OperandFieldID::POP_RD6},
-            {"pop_rd7",    InstMetaData::OperandFieldID::POP_RD7},
-            {"pop_rd8",    InstMetaData::OperandFieldID::POP_RD8},
-            {"pop_rd9",    InstMetaData::OperandFieldID::POP_RD9},
-            {"pop_rd10",   InstMetaData::OperandFieldID::POP_RD10},
-            {"pop_rd11",   InstMetaData::OperandFieldID::POP_RD11},
-            {"pop_rd12",   InstMetaData::OperandFieldID::POP_RD12},
-            {"pop_rd13",   InstMetaData::OperandFieldID::POP_RD13},
-        });
+        {"rs1",        InstMetaData::OperandFieldID::RS1       },
+        {"rs2",        InstMetaData::OperandFieldID::RS2       },
+        {"rs3",        InstMetaData::OperandFieldID::RS3       },
+        {"rs4",        InstMetaData::OperandFieldID::RS4       },
+        {"rs_max",     InstMetaData::OperandFieldID::RS_MAX    },
+        {"fused_sd_0", InstMetaData::OperandFieldID::FUSED_SD_0},
+        {"fused_sd_1", InstMetaData::OperandFieldID::FUSED_SD_1},
+        {"temp_rs1",   InstMetaData::OperandFieldID::TEMP_RS1  },
+        {"temp_rs2",   InstMetaData::OperandFieldID::TEMP_RS2  },
+        {"temp_rs3",   InstMetaData::OperandFieldID::TEMP_RS3  },
+        {"push_rs1",   InstMetaData::OperandFieldID::PUSH_RS1  },
+        {"push_rs2",   InstMetaData::OperandFieldID::PUSH_RS2  },
+        {"push_rs3",   InstMetaData::OperandFieldID::PUSH_RS3  },
+        {"push_rs4",   InstMetaData::OperandFieldID::PUSH_RS4  },
+        {"push_rs5",   InstMetaData::OperandFieldID::PUSH_RS5  },
+        {"push_rs6",   InstMetaData::OperandFieldID::PUSH_RS6  },
+        {"push_rs7",   InstMetaData::OperandFieldID::PUSH_RS7  },
+        {"push_rs8",   InstMetaData::OperandFieldID::PUSH_RS8  },
+        {"push_rs9",   InstMetaData::OperandFieldID::PUSH_RS9  },
+        {"push_rs10",  InstMetaData::OperandFieldID::PUSH_RS10 },
+        {"push_rs11",  InstMetaData::OperandFieldID::PUSH_RS11 },
+        {"push_rs12",  InstMetaData::OperandFieldID::PUSH_RS12 },
+        {"push_rs13",  InstMetaData::OperandFieldID::PUSH_RS13 },
+        {"rd",         InstMetaData::OperandFieldID::RD        },
+        {"rd1",        InstMetaData::OperandFieldID::RD1       },
+        {"rd2",        InstMetaData::OperandFieldID::RD2       },
+        {"rd_max",     InstMetaData::OperandFieldID::RD_MAX    },
+        {"fused_rd_0", InstMetaData::OperandFieldID::FUSED_RD_0},
+        {"fused_rd_1", InstMetaData::OperandFieldID::FUSED_RD_1},
+        {"temp_rd",    InstMetaData::OperandFieldID::TEMP_RD   },
+        {"temp_rd2",   InstMetaData::OperandFieldID::TEMP_RD2  },
+        {"pop_rd1",    InstMetaData::OperandFieldID::POP_RD1   },
+        {"pop_rd2",    InstMetaData::OperandFieldID::POP_RD2   },
+        {"pop_rd3",    InstMetaData::OperandFieldID::POP_RD3   },
+        {"pop_rd4",    InstMetaData::OperandFieldID::POP_RD4   },
+        {"pop_rd5",    InstMetaData::OperandFieldID::POP_RD5   },
+        {"pop_rd6",    InstMetaData::OperandFieldID::POP_RD6   },
+        {"pop_rd7",    InstMetaData::OperandFieldID::POP_RD7   },
+        {"pop_rd8",    InstMetaData::OperandFieldID::POP_RD8   },
+        {"pop_rd9",    InstMetaData::OperandFieldID::POP_RD9   },
+        {"pop_rd10",   InstMetaData::OperandFieldID::POP_RD10  },
+        {"pop_rd11",   InstMetaData::OperandFieldID::POP_RD11  },
+        {"pop_rd12",   InstMetaData::OperandFieldID::POP_RD12  },
+        {"pop_rd13",   InstMetaData::OperandFieldID::POP_RD13  },
+    });
 
     /**
      * Construct from JSON information pertaining to extraction
      */
-    InstMetaData::InstMetaData(const json & inst, bool compressed,
-                               const MatchSet<Tag> & tags) :
+    InstMetaData::InstMetaData(const json & inst, bool compressed, const MatchSet<Tag> & tags) :
         compressed_(compressed),
         tags_(tags)
     {
 
-        if (ofimap.size() != size_t(OperandFieldID::__N)) {
+        if (ofimap.size() != size_t(OperandFieldID::__N))
+        {
             std::cerr << "MAVIS: ofimap size is not the same as the OperandFieldID enum class"
                       << "\n\tUpdate the map in " << __FILE__ << std::endl;
             exit(-1);
         }
 
-        if (isamap.size() != size_t(ISAExtensionIndex::__N)) {
+        if (isamap.size() != size_t(ISAExtensionIndex::__N))
+        {
             std::cerr << "MAVIS: isamap size is not the same as the ISAExtensionIndex enum class"
                       << "\n\tUpdate the map in " << __FILE__ << std::endl;
             exit(-1);
@@ -152,7 +153,7 @@ namespace mavis
         // Word operand types
         if (const auto it = inst.find("w-oper"); it != inst.end())
         {
-            const auto& it_value = it->value();
+            const auto & it_value = it->value();
             if (it_value == "all")
             {
                 setAllOperandsType_(OperandTypes::WORD);
@@ -168,7 +169,7 @@ namespace mavis
         // Long operand types
         if (const auto it = inst.find("l-oper"); it != inst.end())
         {
-            const auto& it_value = it->value();
+            const auto & it_value = it->value();
             if (it_value == "all")
             {
                 setAllOperandsType_(OperandTypes::LONG);
@@ -184,7 +185,7 @@ namespace mavis
         // Single operand types
         if (const auto it = inst.find("s-oper"); it != inst.end())
         {
-            const auto& it_value = it->value();
+            const auto & it_value = it->value();
             if (it_value == "all")
             {
                 setAllOperandsType_(OperandTypes::SINGLE);
@@ -200,7 +201,7 @@ namespace mavis
         // Double operand types
         if (const auto it = inst.find("d-oper"); it != inst.end())
         {
-            const auto& it_value = it->value();
+            const auto & it_value = it->value();
             if (it_value == "all")
             {
                 setAllOperandsType_(OperandTypes::DOUBLE);
@@ -216,7 +217,7 @@ namespace mavis
         // Quad operand types
         if (const auto it = inst.find("q-oper"); it != inst.end())
         {
-            const auto& it_value = it->value();
+            const auto & it_value = it->value();
             if (it_value == "all")
             {
                 setAllOperandsType_(OperandTypes::QUAD);
@@ -232,7 +233,7 @@ namespace mavis
         // Vector operand types
         if (const auto it = inst.find("v-oper"); it != inst.end())
         {
-            const auto& it_value = it->value();
+            const auto & it_value = it->value();
             if (it_value == "all")
             {
                 setAllOperandsType_(OperandTypes::VECTOR);
@@ -265,22 +266,23 @@ namespace mavis
                         {
                             isa_ext_ |=
                                 (1ull << static_cast<std::underlying_type_t<ISAExtensionIndex>>(
-                                    itr->second));
+                                     itr->second));
                         }
                         else
                         {
                             // Invalid ISA extension letter
-                            throw BuildErrorInvalidISAExtension(boost::json::value_to<std::string>(inst.at("mnemonic")), s,
-                                                                matches[2].str());
+                            throw BuildErrorInvalidISAExtension(
+                                boost::json::value_to<std::string>(inst.at("mnemonic")), s,
+                                matches[2].str());
                         }
                         if (matches[1].length() != 0)
                         {
-                            const uint32_t n =
-                                std::strtoull(matches[1].str().c_str(), nullptr, 0);
+                            const uint32_t n = std::strtoull(matches[1].str().c_str(), nullptr, 0);
                             if ((n == 0) || ((n & (n - 1)) != 0))
                             {
                                 // Not a non-zero power of 2
-                                throw BuildErrorInvalidISAWidth(boost::json::value_to<std::string>(inst.at("mnemonic")), s, n);
+                                throw BuildErrorInvalidISAWidth(
+                                    boost::json::value_to<std::string>(inst.at("mnemonic")), s, n);
                             }
                             setISAWidth(itr->second, n);
                         }
@@ -288,7 +290,8 @@ namespace mavis
                     else
                     {
                         // Malformed ISA extension string
-                        throw BuildErrorMalformedISAExtension(boost::json::value_to<std::string>(inst.at("mnemonic")), s);
+                        throw BuildErrorMalformedISAExtension(
+                            boost::json::value_to<std::string>(inst.at("mnemonic")), s);
                     }
                 }
             }
@@ -306,10 +309,10 @@ namespace mavis
                 const auto itr = tmap.left.find(t);
                 if (itr == tmap.left.end())
                 {
-                    throw BuildErrorUnknownType(boost::json::value_to<std::string>(inst.at("mnemonic")), t);
+                    throw BuildErrorUnknownType(
+                        boost::json::value_to<std::string>(inst.at("mnemonic")), t);
                 }
-                inst_types_ |=
-                    static_cast<std::underlying_type_t<InstructionTypes>>(itr->second);
+                inst_types_ |= static_cast<std::underlying_type_t<InstructionTypes>>(itr->second);
             }
         }
     }
@@ -323,12 +326,14 @@ namespace mavis
             // Check positive, power-of-2 or zero
             if ((data_size_ & (data_size_ - 1)) || (int32_t(data_size_) < 0))
             {
-                throw BuildErrorInvalidDataSize(boost::json::value_to<std::string>(inst.at("mnemonic")), data_size_);
+                throw BuildErrorInvalidDataSize(
+                    boost::json::value_to<std::string>(inst.at("mnemonic")), data_size_);
             }
         }
     }
 
-    std::underlying_type_t<InstMetaData::OperandFieldID> InstMetaData::getFieldIndex_(const std::string & fname)
+    std::underlying_type_t<InstMetaData::OperandFieldID>
+    InstMetaData::getFieldIndex_(const std::string & fname)
     {
         const auto itr = ofimap.left.find(fname);
         if (itr == ofimap.left.end())
@@ -362,5 +367,4 @@ namespace mavis
     const std::regex InstMetaData::isa_ext_pattern_ =
         std::regex("([1-9][0-9]*?)?([A-Z])", std::regex::optimize);
 
-
-}
+} // namespace mavis

--- a/impl/forms/CompressedForms.cpp
+++ b/impl/forms/CompressedForms.cpp
@@ -394,10 +394,11 @@ namespace mavis
      */
     const char* Form_CMPP::name{"CMPP"};
 
-    const FieldsType Form_CMPP::fields{Field("func3", 13, 3), Field("func1", 12, 1), // func6 is split into func3, func1, and func2A
-                                       Field("func2A", 10, 2), Field("func2", 8, 2),
-                                       Field("urlist", 4, 4), Field("spimm", 2, 2),
-                                       Field("opcode", 0, 2)};
+    const FieldsType Form_CMPP::fields{
+        Field("func3", 13, 3),  Field("func1", 12, 1), // func6 is split into func3, func1, and
+                                                       // func2A
+        Field("func2A", 10, 2), Field("func2", 8, 2),  Field("urlist", 4, 4),
+        Field("spimm", 2, 2),   Field("opcode", 0, 2)};
 
     const std::map<std::string, const Field &> Form_CMPP::fmap{
         {"func3",  Form_CMPP::fields[Form_CMPP::idType::FUNC3] },
@@ -419,11 +420,10 @@ namespace mavis
         {"opcode", Form_CMPP::idType::OPCODE}
     };
 
-    const FieldsType Form_CMPP::opcode_fields{Form_CMPP::fields[Form_CMPP::idType::OPCODE],
-                                              Form_CMPP::fields[Form_CMPP::idType::FUNC3],
-                                              Form_CMPP::fields[Form_CMPP::idType::FUNC2A],
-                                              Form_CMPP::fields[Form_CMPP::idType::FUNC1],
-                                              Form_CMPP::fields[Form_CMPP::idType::FUNC2]};
+    const FieldsType Form_CMPP::opcode_fields{
+        Form_CMPP::fields[Form_CMPP::idType::OPCODE], Form_CMPP::fields[Form_CMPP::idType::FUNC3],
+        Form_CMPP::fields[Form_CMPP::idType::FUNC2A], Form_CMPP::fields[Form_CMPP::idType::FUNC1],
+        Form_CMPP::fields[Form_CMPP::idType::FUNC2]};
 
     const ImmediateType Form_CMPP::immediate_type = ImmediateType::SIGNED;
 
@@ -432,9 +432,10 @@ namespace mavis
      */
     const char* Form_CMJT::name{"CMJT"};
 
-    const FieldsType Form_CMJT::fields{Field("func3", 13, 3), Field("func1", 12, 1), // func6 is split into func3, func1, and func2A
-                                       Field("func2A", 10, 2),Field("index", 2, 8),
-                                       Field("opcode", 0, 2)};
+    const FieldsType Form_CMJT::fields{
+        Field("func3", 13, 3),
+        Field("func1", 12, 1), // func6 is split into func3, func1, and func2A
+        Field("func2A", 10, 2), Field("index", 2, 8), Field("opcode", 0, 2)};
 
     const std::map<std::string, const Field &> Form_CMJT::fmap{
         {"func3",  Form_CMJT::fields[Form_CMJT::idType::FUNC3] },
@@ -452,10 +453,9 @@ namespace mavis
         {"opcode", Form_CMJT::idType::OPCODE}
     };
 
-    const FieldsType Form_CMJT::opcode_fields{Form_CMJT::fields[Form_CMJT::idType::OPCODE],
-                                              Form_CMJT::fields[Form_CMJT::idType::FUNC3],
-                                              Form_CMJT::fields[Form_CMJT::idType::FUNC2A],
-                                              Form_CMJT::fields[Form_CMJT::idType::FUNC1]};
+    const FieldsType Form_CMJT::opcode_fields{
+        Form_CMJT::fields[Form_CMJT::idType::OPCODE], Form_CMJT::fields[Form_CMJT::idType::FUNC3],
+        Form_CMJT::fields[Form_CMJT::idType::FUNC2A], Form_CMJT::fields[Form_CMJT::idType::FUNC1]};
 
     const ImmediateType Form_CMJT::immediate_type = ImmediateType::UNSIGNED;
 

--- a/impl/forms/ExtractorDerived.h
+++ b/impl/forms/ExtractorDerived.h
@@ -1594,10 +1594,8 @@ namespace mavis
      * Derivative of Form_C2 extractor with implicit x0 source
      * For c.mv extraction
      *
-     * NOTE: the x0 implicit source insertion is not being used right now, since dabble
-     * rename cannot yet handle a 2-source move. C.MV may be transformed to CMOV in
-     * dabble, so the x0 source needs to be "replaced" in CMOV with the destination
-     * register (to preserve the old value if the condition fails)
+     * NOTE: the x0 implicit source insertion is not being used right
+     * now.
      */
     template <> class Extractor<Form_C2_mv> : public Extractor<Form_C2>
     {

--- a/impl/forms/ExtractorDerived.h
+++ b/impl/forms/ExtractorDerived.h
@@ -2405,9 +2405,9 @@ namespace mavis
             return InstMetaData::OperandFieldID::PUSH_RS1;
         }
 
-        int64_t getStackAdjBase_(const Opcode icode, const InstMetaData::PtrType & meta) const override
+        int64_t getStackAdjBase_(const Opcode icode, const uint32_t data_size) const override
         {
-            return -1 * Extractor<Form_CMPP>::getStackAdjBase_(icode, meta);
+            return -1 * Extractor<Form_CMPP>::getStackAdjBase_(icode, data_size);
         }
     };
 
@@ -2786,37 +2786,6 @@ namespace mavis
             appendUnmaskedOperandInfo_(olist, icode, meta, InstMetaData::OperandFieldID::RS2,
                                        fixed_field_mask_, Form_V::idType::RS2, false, suppress_x0);
             return olist;
-        }
-
-        // TODO: add VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
-        {
-            switch (sfid)
-            {
-                case SpecialField::VM:
-                    if (isMaskedField_(Form_V::idType::VM, fixed_field_mask_))
-                    {
-                        throw UnsupportedExtractorSpecialFieldID("VM", icode);
-                    }
-                    else
-                    {
-                        return extract_(Form_V::idType::VM, icode);
-                    }
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::CSR:
-                case SpecialField::FM:
-                case SpecialField::HINT:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::RL:
-                case SpecialField::RM:
-                case SpecialField::SUCC:
-                case SpecialField::WD:
-                case SpecialField::__N:
-                    return ExtractorBase::getSpecialField(sfid, icode);
-            }
-            return 0;
         }
 
         uint64_t getImmediate(const Opcode icode) const override

--- a/impl/forms/ExtractorDerived.h
+++ b/impl/forms/ExtractorDerived.h
@@ -27,10 +27,7 @@ namespace mavis
         ImmediateType getImmediateType() const override { return ImmediateType::NONE; }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_I>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_I>(ffmask, fset) {}
     };
 
     /**
@@ -56,10 +53,7 @@ namespace mavis
         }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_I>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_I>(ffmask, fset) {}
 
         friend Extractor<Form_I_load_pair>;
     };
@@ -115,8 +109,7 @@ namespace mavis
         }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_I_load>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_I_load>(ffmask, fset)
         {
         }
     };
@@ -172,10 +165,7 @@ namespace mavis
         // clang-format on
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C0>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C0>(ffmask, fset) {}
     };
 
     /**
@@ -538,10 +528,7 @@ namespace mavis
         // clang-format on
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C0>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C0>(ffmask, fset) {}
     };
 
     /**
@@ -896,8 +883,7 @@ namespace mavis
         uint64_t getImmediate(const Opcode icode) const override { return 0; }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C1_rsd>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C1_rsd>(ffmask, fset)
         {
         }
     };
@@ -964,8 +950,7 @@ namespace mavis
         uint64_t getImmediate(const Opcode icode) const override { return 0; }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C1_rsd>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C1_rsd>(ffmask, fset)
         {
         }
     };
@@ -991,8 +976,7 @@ namespace mavis
         uint64_t getImmediate(const Opcode icode) const override { return -1ull; }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C1_rsd>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C1_rsd>(ffmask, fset)
         {
         }
     };
@@ -1018,8 +1002,7 @@ namespace mavis
         uint64_t getImmediate(const Opcode icode) const override { return 0xFF; }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C1_rsd>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C1_rsd>(ffmask, fset)
         {
         }
     };
@@ -1043,10 +1026,7 @@ namespace mavis
         std::string getName() const override { return Form_CI_addi::name; }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_CI>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_CI>(ffmask, fset) {}
     };
 
     /**
@@ -1071,10 +1051,7 @@ namespace mavis
         std::string getName() const override { return Form_CI_addiw::name; }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_CI>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_CI>(ffmask, fset) {}
     };
 
     /**
@@ -1265,10 +1242,7 @@ namespace mavis
         // clang-format on
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_CIW>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_CIW>(ffmask, fset) {}
     };
 
     /**
@@ -1297,10 +1271,7 @@ namespace mavis
         }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_CIX>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_CIX>(ffmask, fset) {}
     };
 
     /**
@@ -1367,10 +1338,7 @@ namespace mavis
         }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_CJ>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_CJ>(ffmask, fset) {}
     };
 
     /**
@@ -1481,10 +1449,7 @@ namespace mavis
         // clang-format on
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_CJR>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_CJR>(ffmask, fset) {}
     };
 
     /**
@@ -1584,10 +1549,7 @@ namespace mavis
         // clang-format on
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C2>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C2>(ffmask, fset) {}
     };
 
     /**
@@ -1685,10 +1647,7 @@ namespace mavis
         // clang-format on
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C2>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C2>(ffmask, fset) {}
     };
 
     /**
@@ -1786,10 +1745,7 @@ namespace mavis
         // clang-format on
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C2>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C2>(ffmask, fset) {}
     };
 
     /**
@@ -1884,10 +1840,7 @@ namespace mavis
         // clang-format on
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C2>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C2>(ffmask, fset) {}
     };
 
     /**
@@ -1934,8 +1887,7 @@ namespace mavis
         ImmediateType getImmediateType() const override { return ImmediateType::UNSIGNED; }
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_C2_sp>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_C2_sp>(ffmask, fset)
         {
         }
     };
@@ -2368,13 +2320,15 @@ namespace mavis
 
         uint64_t getSourceRegs(const Opcode icode) const override
         {
-            // Form_CMPP handles pop-type instructions. On a push, the source and dest regs are swapped
+            // Form_CMPP handles pop-type instructions. On a push, the source and dest regs are
+            // swapped
             return Extractor<Form_CMPP>::getDestRegs(icode);
         }
 
         uint64_t getDestRegs(const Opcode icode) const override
         {
-            // Form_CMPP handles pop-type instructions. On a push, the source and dest regs are swapped
+            // Form_CMPP handles pop-type instructions. On a push, the source and dest regs are
+            // swapped
             return Extractor<Form_CMPP>::getSourceRegs(icode);
         }
 
@@ -2443,8 +2397,7 @@ namespace mavis
         uint64_t getSourceOperTypeRegs(const Opcode icode, const InstMetaData::PtrType & meta,
                                        InstMetaData::OperandTypes kind) const override
         {
-            if (meta->isAllOperandType(kind)
-                || (kind == InstMetaData::OperandTypes::LONG)
+            if (meta->isAllOperandType(kind) || (kind == InstMetaData::OperandTypes::LONG)
                 || (kind == InstMetaData::OperandTypes::WORD))
             {
                 return getSourceRegs(icode);
@@ -2458,8 +2411,7 @@ namespace mavis
         uint64_t getDestOperTypeRegs(const Opcode icode, const InstMetaData::PtrType & meta,
                                      InstMetaData::OperandTypes kind) const override
         {
-            if (meta->isAllOperandType(kind)
-                || (kind == InstMetaData::OperandTypes::LONG)
+            if (meta->isAllOperandType(kind) || (kind == InstMetaData::OperandTypes::LONG)
                 || (kind == InstMetaData::OperandTypes::WORD))
             {
                 return getDestRegs(icode);
@@ -2580,8 +2532,7 @@ namespace mavis
         std::string getName() const override { return Form_V_load::name; }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_VF_mem>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_VF_mem>(ffmask, fset)
         {
         }
     };
@@ -2729,8 +2680,7 @@ namespace mavis
         // clang-format on
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_VF_mem>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_VF_mem>(ffmask, fset)
         {
         }
     };
@@ -2836,10 +2786,7 @@ namespace mavis
         // clang-format on
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_V>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_V>(ffmask, fset) {}
     };
 
     /**
@@ -2911,8 +2858,7 @@ namespace mavis
         // clang-format on
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_V_uimm>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_V_uimm>(ffmask, fset)
         {
         }
     };
@@ -2974,10 +2920,7 @@ namespace mavis
         // clang-format on
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_V>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_V>(ffmask, fset) {}
     };
 
     /**
@@ -3025,10 +2968,7 @@ namespace mavis
         // clang-format on
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_R>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_R>(ffmask, fset) {}
     };
 
     /**
@@ -3128,10 +3068,7 @@ namespace mavis
         // clang-format on
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            fixed_field_mask_(ffmask)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : fixed_field_mask_(ffmask) {}
 
         uint64_t fixed_field_mask_ = 0;
     };
@@ -3186,10 +3123,7 @@ namespace mavis
         }
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_V>(ffmask, fset)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_V>(ffmask, fset) {}
     };
 
     /**
@@ -3243,8 +3177,7 @@ namespace mavis
         }
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_V_op>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_V_op>(ffmask, fset)
         {
         }
     };
@@ -3300,8 +3233,7 @@ namespace mavis
         }
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            Extractor<Form_V_uimm>(ffmask, fset)
+        Extractor(const uint64_t ffmask, const uint64_t fset) : Extractor<Form_V_uimm>(ffmask, fset)
         {
         }
     };
@@ -3337,10 +3269,7 @@ namespace mavis
         }
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            fixed_field_mask_(ffmask)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : fixed_field_mask_(ffmask) {}
 
         uint64_t fixed_field_mask_ = 0;
     };
@@ -3449,10 +3378,7 @@ namespace mavis
         // clang-format on
 
       protected:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            fixed_field_mask_(ffmask)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : fixed_field_mask_(ffmask) {}
 
         uint64_t fixed_field_mask_ = 0;
     };

--- a/impl/forms/ExtractorForms.h
+++ b/impl/forms/ExtractorForms.h
@@ -135,7 +135,7 @@ namespace mavis
             return olist;
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
         {
             switch (sfid)
             {
@@ -152,15 +152,7 @@ namespace mavis
                     return extract_(Form_AMO::idType::VM, icode);
                 case SpecialField::WD:
                     return extract_(Form_AMO::idType::WD, icode);
-                case SpecialField::AVL:
-                case SpecialField::RM:
-                case SpecialField::CSR:
-                case SpecialField::FM:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::SUCC:
-                case SpecialField::__N:
+                default:
                     return ExtractorBase::getSpecialField(sfid, icode);
             }
             return 0;
@@ -1684,10 +1676,19 @@ namespace mavis
             return extract_(Form_CMPP::idType::SPIMM, icode) << 4;
         }
 
-        uint64_t getSourceRegs(const Opcode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & meta) const override
         {
-            return 1ull << REGISTER_SP;
+            if (sfid == SpecialField::STACK_ADJ) {
+                if (meta == nullptr) {
+                    throw std::runtime_error("Cannot retrieve SF stack_adj with the original meta data");
+                }
+                return getStackAdj_(icode, meta->getDataSize());
+            }
+            return ExtractorBase::getSpecialField(sfid, icode);
         }
+
+        uint64_t getSourceRegs(const Opcode) const override { return 1ull << REGISTER_SP; }
 
         uint64_t getDestRegs(const Opcode icode) const override
         {
@@ -1697,8 +1698,7 @@ namespace mavis
         uint64_t getSourceOperTypeRegs(const Opcode icode, const InstMetaData::PtrType & meta,
                                        InstMetaData::OperandTypes kind) const override
         {
-            if (meta->isAllOperandType(kind)
-                || (kind == InstMetaData::OperandTypes::LONG)
+            if (meta->isAllOperandType(kind) || (kind == InstMetaData::OperandTypes::LONG)
                 || (kind == InstMetaData::OperandTypes::WORD))
             {
                 return getSourceRegs(icode);
@@ -1712,8 +1712,7 @@ namespace mavis
         uint64_t getDestOperTypeRegs(const Opcode icode, const InstMetaData::PtrType & meta,
                                      InstMetaData::OperandTypes kind) const override
         {
-            if (meta->isAllOperandType(kind)
-                || (kind == InstMetaData::OperandTypes::LONG)
+            if (meta->isAllOperandType(kind) || (kind == InstMetaData::OperandTypes::LONG)
                 || (kind == InstMetaData::OperandTypes::WORD))
             {
                 return getDestRegs(icode);
@@ -1752,9 +1751,8 @@ namespace mavis
         {
             std::stringstream ss;
             ss << mnemonic << '\t';
-            formatRList_(ss, icode, [&ss](const uint64_t urlist) {
-                ss << getRListRangeEnd_(urlist);
-            });
+            formatRList_(ss, icode,
+                         [&ss](const uint64_t urlist) { ss << getRListRangeEnd_(urlist); });
             ss << ", " << getSignedOffset(icode);
             return ss.str();
         }
@@ -1769,7 +1767,7 @@ namespace mavis
                 ss << dasmFormatReg_(meta, op_id, getRListRangeEnd_(urlist));
                 op_id = incrementFieldID_(op_id);
             });
-            ss << ", " << getStackAdj_(icode, meta);
+            ss << ", " << getStackAdj_(icode, meta->getDataSize());
             return ss.str();
         }
 
@@ -1782,37 +1780,39 @@ namespace mavis
         {
         }
 
-        virtual int64_t getStackAdjBase_(const Opcode icode, const InstMetaData::PtrType & meta) const
+        virtual int64_t getStackAdjBase_(const Opcode icode,
+                                         const uint32_t data_size) const
         {
             const auto urlist = extract_(Form_CMPP::idType::URLIST, icode);
             const auto [begin, end] = getRListRange_(urlist);
             const auto num_regs = std::distance(begin, end);
-            const auto reg_size_bytes = meta->getDataSize() / 8;
+            const auto reg_size_bytes = data_size / 8;
             // Round up to the nearest multiple of 16
             return (num_regs * reg_size_bytes + 15) & -16ll;
         }
 
-        int64_t getStackAdj_(const Opcode icode, const InstMetaData::PtrType & meta) const
+        int64_t getStackAdj_(const Opcode icode, const uint32_t data_size) const
         {
-            return getStackAdjBase_(icode, meta) + getSignedOffset(icode);
+            return getStackAdjBase_(icode, data_size) + getSignedOffset(icode);
         }
 
-        template<typename FormatFunc>
-        static void formatRList_(std::stringstream& ss, const Opcode icode, FormatFunc&& format_func)
+        template <typename FormatFunc>
+        static void formatRList_(std::stringstream & ss, const Opcode icode,
+                                 FormatFunc && format_func)
         {
             const auto urlist = extract_(Form_CMPP::idType::URLIST, icode);
 
             ss << "{";
 
-            for(const auto& range: RLIST_RANGES_)
+            for (const auto & range : RLIST_RANGES_)
             {
                 const auto urlist_begin = range.first;
 
-                if(urlist < urlist_begin)
+                if (urlist < urlist_begin)
                 {
                     break;
                 }
-                else if(urlist_begin > MIN_URLIST_)
+                else if (urlist_begin > MIN_URLIST_)
                 {
                     ss << ", ";
                 }
@@ -1821,7 +1821,7 @@ namespace mavis
 
                 format_func(urlist_begin);
 
-                if(urlist_begin == urlist_end)
+                if (urlist_begin == urlist_end)
                 {
                     continue;
                 }
@@ -1839,29 +1839,32 @@ namespace mavis
         inline static constexpr size_t NUM_RLIST_ENTRIES_ = 13;
         using RListArray = std::array<uint32_t, NUM_RLIST_ENTRIES_>;
         inline static constexpr RListArray RLIST_{
-            REGISTER_LINK,  // urlist >= 0x4
-            8,              // urlist >= 0x5
-            9,              // urlist >= 0x6
-            18,             // urlist >= 0x7
-            19,             // urlist >= 0x8
-            20,             // urlist >= 0x9
-            21,             // urlist >= 0xa
-            22,             // urlist >= 0xb
-            23,             // urlist >= 0xc
-            24,             // urlist >= 0xd
-            25,             // urlist >= 0xe
-            // These two entries *both* belong to urlist == 0xf - this special case is handled in getRListRange_
-            26,
-            27
+            REGISTER_LINK, // urlist >= 0x4
+            8,             // urlist >= 0x5
+            9,             // urlist >= 0x6
+            18,            // urlist >= 0x7
+            19,            // urlist >= 0x8
+            20,            // urlist >= 0x9
+            21,            // urlist >= 0xa
+            22,            // urlist >= 0xb
+            23,            // urlist >= 0xc
+            24,            // urlist >= 0xd
+            25,            // urlist >= 0xe
+            // These two entries *both* belong to urlist == 0xf - this special case is handled in
+            // getRListRange_
+            26, 27};
+
+        inline static constexpr std::array<std::pair<uint64_t, uint64_t>, 3> RLIST_RANGES_{
+            {{MIN_URLIST_, MIN_URLIST_}, {0x5, 0x6}, {0x7, MAX_URLIST_}}
         };
 
-        inline static constexpr std::array<std::pair<uint64_t, uint64_t>, 3> RLIST_RANGES_{{{MIN_URLIST_, MIN_URLIST_},
-                                                                                            {0x5, 0x6},
-                                                                                            {0x7, MAX_URLIST_}}};
-
-        static constexpr std::pair<RListArray::const_iterator, RListArray::const_iterator> getRListRange_(const uint64_t urlist)
+        static constexpr std::pair<RListArray::const_iterator, RListArray::const_iterator>
+        getRListRange_(const uint64_t urlist)
         {
-            return std::make_pair(RLIST_.begin(), urlist == MAX_URLIST_ ? RLIST_.end() : std::next(RLIST_.begin(), urlist - MIN_URLIST_ + 1));
+            return std::make_pair(RLIST_.begin(),
+                                  urlist == MAX_URLIST_
+                                      ? RLIST_.end()
+                                      : std::next(RLIST_.begin(), urlist - MIN_URLIST_ + 1));
         }
 
         static constexpr uint32_t getRListRangeEnd_(const uint64_t urlist)
@@ -1877,7 +1880,7 @@ namespace mavis
 
             const auto [begin, end] = getRListRange_(urlist);
 
-            for(auto it = begin; it != end; ++it)
+            for (auto it = begin; it != end; ++it)
             {
                 regs |= (1ull << *it);
             }
@@ -1885,9 +1888,11 @@ namespace mavis
             return regs;
         }
 
-        static constexpr InstMetaData::OperandFieldID incrementFieldID_(const InstMetaData::OperandFieldID op_id)
+        static constexpr InstMetaData::OperandFieldID
+        incrementFieldID_(const InstMetaData::OperandFieldID op_id)
         {
-            return static_cast<InstMetaData::OperandFieldID>(static_cast<std::underlying_type_t<InstMetaData::OperandFieldID>>(op_id) + 1);
+            return static_cast<InstMetaData::OperandFieldID>(
+                static_cast<std::underlying_type_t<InstMetaData::OperandFieldID>>(op_id) + 1);
         }
 
         virtual InstMetaData::OperandFieldID getFirstOperandID_() const
@@ -1895,8 +1900,7 @@ namespace mavis
             return InstMetaData::OperandFieldID::POP_RD1;
         }
 
-        void convertRListToOpcodeInfo_(OperandInfo& olist,
-                                       const Opcode icode,
+        void convertRListToOpcodeInfo_(OperandInfo & olist, const Opcode icode,
                                        const InstMetaData::OperandTypes op_type) const
         {
             const auto urlist = extract_(Form_CMPP::idType::URLIST, icode);
@@ -1905,7 +1909,7 @@ namespace mavis
 
             InstMetaData::OperandFieldID op_id = getFirstOperandID_();
 
-            for(auto it = begin; it != end; ++it)
+            for (auto it = begin; it != end; ++it)
             {
                 olist.addElement(op_id, op_type, *it, true);
                 op_id = incrementFieldID_(op_id);
@@ -1936,7 +1940,7 @@ namespace mavis
 
         uint64_t getDestRegs(const Opcode icode) const override
         {
-            if(isJALT_(icode))
+            if (isJALT_(icode))
             {
                 return 1ull << REGISTER_LINK;
             }
@@ -1947,8 +1951,7 @@ namespace mavis
         uint64_t getDestOperTypeRegs(const Opcode icode, const InstMetaData::PtrType & meta,
                                      InstMetaData::OperandTypes kind) const override
         {
-            if (meta->isAllOperandType(kind)
-                || (kind == InstMetaData::OperandTypes::LONG)
+            if (meta->isAllOperandType(kind) || (kind == InstMetaData::OperandTypes::LONG)
                 || (kind == InstMetaData::OperandTypes::WORD))
             {
                 return getDestRegs(icode);
@@ -1963,7 +1966,7 @@ namespace mavis
                                        bool suppress_x0 = false) const override
         {
             OperandInfo olist;
-            if(isJALT_(icode))
+            if (isJALT_(icode))
             {
                 const auto op_type = meta->getOperandType(InstMetaData::OperandFieldID::RD);
                 olist.addElement(InstMetaData::OperandFieldID::RD, op_type, REGISTER_LINK, false);
@@ -1988,10 +1991,7 @@ namespace mavis
         {
         }
 
-        bool isJALT_(const Opcode icode) const
-        {
-            return getImmediate(icode) >= 32;
-        }
+        bool isJALT_(const Opcode icode) const { return getImmediate(icode) >= 32; }
 
         inline static const std::string jalt_mnemonic_{"cm.jalt"};
         const uint64_t fixed_field_set_ = 0;
@@ -2086,27 +2086,13 @@ namespace mavis
             return olist;
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
         {
-            switch (sfid)
+            if (SpecialField::CSR == sfid)
             {
-                case SpecialField::CSR:
-                    return extract_(Form_CSR::idType::CSR, icode);
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::FM:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::RL:
-                case SpecialField::RM:
-                case SpecialField::SUCC:
-                case SpecialField::VM:
-                case SpecialField::WD:
-                case SpecialField::__N:
-                    return ExtractorBase::getSpecialField(sfid, icode);
+                return extract_(Form_CSR::idType::CSR, icode);
             }
-            return 0;
+            return ExtractorBase::getSpecialField(sfid, icode);
         }
 
         using ExtractorIF::dasmString; // tell the compiler all dasmString
@@ -2203,27 +2189,13 @@ namespace mavis
             return extract_(Form_CSRI::idType::UIMM, icode & ~fixed_field_mask_);
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
         {
-            switch (sfid)
+            if (SpecialField::CSR == sfid)
             {
-                case SpecialField::CSR:
-                    return extract_(Form_CSRI::idType::CSR, icode);
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::FM:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::RL:
-                case SpecialField::RM:
-                case SpecialField::SUCC:
-                case SpecialField::VM:
-                case SpecialField::WD:
-                case SpecialField::__N:
-                    return ExtractorBase::getSpecialField(sfid, icode);
+                return extract_(Form_CSRI::idType::CSR, icode);
             }
-            return 0;
+            return ExtractorBase::getSpecialField(sfid, icode);
         }
 
         using ExtractorIF::dasmString; // tell the compiler all dasmString
@@ -2353,7 +2325,7 @@ namespace mavis
             return olist;
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
         {
             switch (sfid)
             {
@@ -2364,15 +2336,7 @@ namespace mavis
                     return extract_(Form_FENCE::idType::PRED, icode);
                 case SpecialField::SUCC:
                     return extract_(Form_FENCE::idType::SUCC, icode);
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::CSR:
-                case SpecialField::NF:
-                case SpecialField::RL:
-                case SpecialField::RM:
-                case SpecialField::VM:
-                case SpecialField::WD:
-                case SpecialField::__N:
+                default:
                     return ExtractorBase::getSpecialField(sfid, icode);
             }
             return 0;
@@ -3129,27 +3093,13 @@ namespace mavis
             return olist;
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
         {
-            switch (sfid)
+            if (SpecialField::RM == sfid)
             {
-                case SpecialField::RM:
-                    return extract_(Form_Rfloat::idType::RM, icode);
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::CSR:
-                case SpecialField::FM:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::RL:
-                case SpecialField::SUCC:
-                case SpecialField::VM:
-                case SpecialField::WD:
-                case SpecialField::__N:
-                    return ExtractorBase::getSpecialField(sfid, icode);
+                return extract_(Form_Rfloat::idType::RM, icode);
             }
-            return 0;
+            return ExtractorBase::getSpecialField(sfid, icode);
         }
 
         using ExtractorIF::dasmString; // tell the compiler all dasmString
@@ -3191,9 +3141,7 @@ namespace mavis
         // clang-format on
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) : ExtractorBase(ffmask)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : ExtractorBase(ffmask) {}
     };
 
     /**
@@ -3300,27 +3248,13 @@ namespace mavis
             return olist;
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
         {
-            switch (sfid)
+            if (SpecialField::RM == sfid)
             {
-                case SpecialField::RM:
-                    return extract_(Form_R4::idType::RM, icode);
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::CSR:
-                case SpecialField::FM:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::RL:
-                case SpecialField::SUCC:
-                case SpecialField::VM:
-                case SpecialField::WD:
-                case SpecialField::__N:
-                    return ExtractorBase::getSpecialField(sfid, icode);
+                return extract_(Form_R4::idType::RM, icode);
             }
-            return 0;
+            return ExtractorBase::getSpecialField(sfid, icode);
         }
 
         using ExtractorIF::dasmString; // tell the compiler all dasmString
@@ -3671,35 +3605,21 @@ namespace mavis
         }
 
         // TODO: add VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
         {
-            switch (sfid)
+            if (SpecialField::VM == sfid)
             {
                 // TODO: All forms should be using this pattern...
-                case SpecialField::VM:
-                    if (isMaskedField_(Form_V::idType::VM, fixed_field_mask_))
-                    {
-                        throw UnsupportedExtractorSpecialFieldID("VM", icode);
-                    }
-                    else
-                    {
-                        return extract_(Form_V::idType::VM, icode);
-                    }
-                case SpecialField::RM:
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::CSR:
-                case SpecialField::FM:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::RL:
-                case SpecialField::SUCC:
-                case SpecialField::WD:
-                case SpecialField::__N:
-                    return ExtractorBase::getSpecialField(sfid, icode);
+                if (isMaskedField_(Form_V::idType::VM, fixed_field_mask_))
+                {
+                    throw UnsupportedExtractorSpecialFieldID("VM", icode);
+                }
+                else
+                {
+                    return extract_(Form_V::idType::VM, icode);
+                }
             }
-            return 0;
+            return ExtractorBase::getSpecialField(sfid, icode);
         }
 
         std::string dasmString(const std::string & mnemonic, const Opcode icode) const override
@@ -3852,7 +3772,7 @@ namespace mavis
         }
 
         // TODO: add NF and VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
         {
             switch (sfid)
             {
@@ -3868,17 +3788,7 @@ namespace mavis
                     {
                         return extract_(Form_VF_mem::idType::VM, icode);
                     }
-                case SpecialField::RM:
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::CSR:
-                case SpecialField::FM:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::RL:
-                case SpecialField::SUCC:
-                case SpecialField::WD:
-                case SpecialField::__N:
+                default:
                     return ExtractorBase::getSpecialField(sfid, icode);
             }
             return 0;
@@ -4060,29 +3970,6 @@ namespace mavis
             return olist;
         }
 
-        // TODO: add VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
-        {
-            switch (sfid)
-            {
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::CSR:
-                case SpecialField::FM:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::RL:
-                case SpecialField::RM:
-                case SpecialField::SUCC:
-                case SpecialField::VM:
-                case SpecialField::WD:
-                case SpecialField::__N:
-                    return ExtractorBase::getSpecialField(sfid, icode);
-            }
-            return 0;
-        }
-
         uint64_t getImmediate(const Opcode icode) const override
         {
             return extract_(Form_V_vsetvli::idType::IMM11, icode & ~fixed_field_mask_);
@@ -4115,10 +4002,7 @@ namespace mavis
         // clang-format on
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            ExtractorBase(ffmask)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : ExtractorBase(ffmask) {}
     };
 
     /**
@@ -4174,27 +4058,12 @@ namespace mavis
         }
 
         // TODO: add VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
         {
-            switch (sfid)
-            {
-                case SpecialField::AVL:
-                    return extract_(Form_V_vsetivli::idType::AVL, icode);
-                case SpecialField::AQ:
-                case SpecialField::CSR:
-                case SpecialField::FM:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::RL:
-                case SpecialField::RM:
-                case SpecialField::SUCC:
-                case SpecialField::VM:
-                case SpecialField::WD:
-                case SpecialField::__N:
-                    return ExtractorBase::getSpecialField(sfid, icode);
+            if (SpecialField::AVL == sfid) {
+                return extract_(Form_V_vsetivli::idType::AVL, icode);
             }
-            return 0;
+            return ExtractorBase::getSpecialField(sfid, icode);
         }
 
         uint64_t getImmediate(const Opcode icode) const override
@@ -4216,10 +4085,7 @@ namespace mavis
         }
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) :
-            ExtractorBase(ffmask)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : ExtractorBase(ffmask) {}
     };
 
     /**
@@ -4321,29 +4187,6 @@ namespace mavis
             return olist;
         }
 
-        // TODO: add VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
-        {
-            switch (sfid)
-            {
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::CSR:
-                case SpecialField::FM:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::RL:
-                case SpecialField::RM:
-                case SpecialField::SUCC:
-                case SpecialField::VM:
-                case SpecialField::WD:
-                case SpecialField::__N:
-                    return ExtractorBase::getSpecialField(sfid, icode);
-            }
-            return 0;
-        }
-
         std::string dasmString(const std::string & mnemonic, const Opcode icode) const override
         {
             std::stringstream ss;
@@ -4371,9 +4214,7 @@ namespace mavis
         // clang-format on
 
       private:
-        Extractor(const uint64_t ffmask, const uint64_t fset) : ExtractorBase(ffmask)
-        {
-        }
+        Extractor(const uint64_t ffmask, const uint64_t fset) : ExtractorBase(ffmask) {}
     };
 
     /**
@@ -4467,35 +4308,21 @@ namespace mavis
         }
 
         // TODO: add VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
         {
-            switch (sfid)
+            if (SpecialField::VM == sfid)
             {
                 // TODO: All forms should be using this pattern...
-                case SpecialField::VM:
-                    if (isMaskedField_(Form_V_uimm6::idType::VM, fixed_field_mask_))
-                    {
-                        throw UnsupportedExtractorSpecialFieldID("VM", icode);
-                    }
-                    else
-                    {
-                        return extract_(Form_V_uimm6::idType::VM, icode);
-                    }
-                case SpecialField::RM:
-                case SpecialField::AQ:
-                case SpecialField::AVL:
-                case SpecialField::CSR:
-                case SpecialField::FM:
-                case SpecialField::NF:
-                case SpecialField::PRED:
-                case SpecialField::HINT:
-                case SpecialField::RL:
-                case SpecialField::SUCC:
-                case SpecialField::WD:
-                case SpecialField::__N:
-                    return ExtractorBase::getSpecialField(sfid, icode);
+                if (isMaskedField_(Form_V_uimm6::idType::VM, fixed_field_mask_))
+                {
+                    throw UnsupportedExtractorSpecialFieldID("VM", icode);
+                }
+                else
+                {
+                    return extract_(Form_V_uimm6::idType::VM, icode);
+                }
             }
-            return 0;
+            return ExtractorBase::getSpecialField(sfid, icode);
         }
 
         std::string dasmString(const std::string & mnemonic, const Opcode icode) const override

--- a/impl/forms/ExtractorForms.h
+++ b/impl/forms/ExtractorForms.h
@@ -135,7 +135,8 @@ namespace mavis
             return olist;
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & = nullptr) const override
         {
             switch (sfid)
             {
@@ -1679,9 +1680,12 @@ namespace mavis
         uint64_t getSpecialField(SpecialField sfid, Opcode icode,
                                  const InstMetaData::PtrType & meta) const override
         {
-            if (sfid == SpecialField::STACK_ADJ) {
-                if (meta == nullptr) {
-                    throw std::runtime_error("Cannot retrieve SF stack_adj with the original meta data");
+            if (sfid == SpecialField::STACK_ADJ)
+            {
+                if (meta == nullptr)
+                {
+                    throw std::runtime_error(
+                        "Cannot retrieve SF stack_adj with the original meta data");
                 }
                 return getStackAdj_(icode, meta->getDataSize());
             }
@@ -1780,8 +1784,7 @@ namespace mavis
         {
         }
 
-        virtual int64_t getStackAdjBase_(const Opcode icode,
-                                         const uint32_t data_size) const
+        virtual int64_t getStackAdjBase_(const Opcode icode, const uint32_t data_size) const
         {
             const auto urlist = extract_(Form_CMPP::idType::URLIST, icode);
             const auto [begin, end] = getRListRange_(urlist);
@@ -2086,7 +2089,8 @@ namespace mavis
             return olist;
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & = nullptr) const override
         {
             if (SpecialField::CSR == sfid)
             {
@@ -2189,7 +2193,8 @@ namespace mavis
             return extract_(Form_CSRI::idType::UIMM, icode & ~fixed_field_mask_);
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & = nullptr) const override
         {
             if (SpecialField::CSR == sfid)
             {
@@ -2325,7 +2330,8 @@ namespace mavis
             return olist;
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & = nullptr) const override
         {
             switch (sfid)
             {
@@ -3093,7 +3099,8 @@ namespace mavis
             return olist;
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & = nullptr) const override
         {
             if (SpecialField::RM == sfid)
             {
@@ -3248,7 +3255,8 @@ namespace mavis
             return olist;
         }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & = nullptr) const override
         {
             if (SpecialField::RM == sfid)
             {
@@ -3605,7 +3613,8 @@ namespace mavis
         }
 
         // TODO: add VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & = nullptr) const override
         {
             if (SpecialField::VM == sfid)
             {
@@ -3772,7 +3781,8 @@ namespace mavis
         }
 
         // TODO: add NF and VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & = nullptr) const override
         {
             switch (sfid)
             {
@@ -4058,9 +4068,11 @@ namespace mavis
         }
 
         // TODO: add VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & = nullptr) const override
         {
-            if (SpecialField::AVL == sfid) {
+            if (SpecialField::AVL == sfid)
+            {
                 return extract_(Form_V_vsetivli::idType::AVL, icode);
             }
             return ExtractorBase::getSpecialField(sfid, icode);
@@ -4308,7 +4320,8 @@ namespace mavis
         }
 
         // TODO: add VM special fields
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType & = nullptr) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & = nullptr) const override
         {
             if (SpecialField::VM == sfid)
             {

--- a/mavis/DecodedInstInfo.h
+++ b/mavis/DecodedInstInfo.h
@@ -20,8 +20,7 @@ namespace mavis
         typedef std::bitset<64> BitMask;
         // typedef std::vector<uint8_t>                    OperandArray;
         using OperandArray = ExtractorIF::RegListType;
-        using OpInfoList =
-            OperandInfo::ElementList; // For dabble::Instruction, remove after deprecation
+        using OpInfoList = OperandInfo::ElementList;
 
         // Sub-types for the JAL/JALR instructions
         // See RV ISA Spec, section

--- a/mavis/Extractor.h
+++ b/mavis/Extractor.h
@@ -218,7 +218,7 @@ namespace mavis
         uint64_t getSpecialField(SpecialField sfid, Opcode icode,
                                  const InstMetaData::PtrType & meta = nullptr) const override
         {
-            (void) meta;
+            (void)meta;
             switch (sfid)
             {
                 case SpecialField::AQ:

--- a/mavis/Extractor.h
+++ b/mavis/Extractor.h
@@ -23,37 +23,39 @@ namespace mavis
         typedef std::vector<OpcodeFieldValueType> RegListType;
         typedef std::vector<uint32_t> ValueListType;
 
-        // TODO: Maybe make SpecialField into its own class (for string name <--> enum conversions)
+        // TODO: Make SpecialField a boost::bitmap
         enum class SpecialField : uint32_t
         {
-            AQ = 0, // AQ "acquire" bit in lr.w, sc.w, and atomics
-            AVL,    // AVL "immediate" field in vsetivli
-            CSR,    // CSR field in csr* instructions
-            FM,     // FENCE mode bits
-            NF,     // NF field in vector memory instructions
-            PRED,   // FENCE predecessor bits
-            RL,     // RL "release" bit in lr.w, sc.w, and atomics
-            RM,     // RM "rounding mode" bit in FP instructions
-            SUCC,   // FENCE successor bits
-            VM,     // VM bit in vector insts
-            WD,     // WD in vector atomic insts
-            HINT,   // HINT in prefetch operations
+            AQ = 0,    // AQ "acquire" bit in lr.w, sc.w, and atomics
+            AVL,       // AVL "immediate" field in vsetivli
+            CSR,       // CSR field in csr* instructions
+            FM,        // FENCE mode bits
+            NF,        // NF field in vector memory instructions
+            PRED,      // FENCE predecessor bits
+            RL,        // RL "release" bit in lr.w, sc.w, and atomics
+            RM,        // RM "rounding mode" bit in FP instructions
+            SUCC,      // FENCE successor bits
+            VM,        // VM bit in vector insts
+            WD,        // WD in vector atomic insts
+            HINT,      // HINT in prefetch operations
+            STACK_ADJ, // Stack adjustment for zcmp instructions
             __N
         };
 
         static inline const std::map<const std::string, SpecialField> SpecialFieldMap{
-            {"aq",   SpecialField::AQ  },
-            {"avl",  SpecialField::AVL },
-            {"csr",  SpecialField::CSR },
-            {"fm",   SpecialField::FM  },
-            {"nf",   SpecialField::NF  },
-            {"pred", SpecialField::PRED},
-            {"rl",   SpecialField::RL  },
-            {"rm",   SpecialField::RM  },
-            {"succ", SpecialField::SUCC},
-            {"vm",   SpecialField::VM  },
-            {"wd",   SpecialField::WD  },
-            {"hint", SpecialField::HINT}
+            {"aq",        SpecialField::AQ       },
+            {"avl",       SpecialField::AVL      },
+            {"csr",       SpecialField::CSR      },
+            {"fm",        SpecialField::FM       },
+            {"nf",        SpecialField::NF       },
+            {"pred",      SpecialField::PRED     },
+            {"rl",        SpecialField::RL       },
+            {"rm",        SpecialField::RM       },
+            {"succ",      SpecialField::SUCC     },
+            {"vm",        SpecialField::VM       },
+            {"wd",        SpecialField::WD       },
+            {"hint",      SpecialField::HINT     },
+            {"stack_adj", SpecialField::STACK_ADJ}
         };
 
       private:
@@ -123,7 +125,8 @@ namespace mavis
         // ExtractorTraceInfo. Do we really need separate versions anymore?
         virtual int64_t getSignedOffset(Opcode icode) const = 0;
 
-        virtual uint64_t getSpecialField(SpecialField sfid, Opcode icode) const = 0;
+        virtual uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                         const InstMetaData::PtrType & meta = nullptr) const = 0;
 
         virtual std::string dasmString(const std::string & mnemonic, Opcode icode) const = 0;
 
@@ -212,8 +215,10 @@ namespace mavis
 
         int64_t getSignedOffset(const Opcode icode) const override { return getImmediate(icode); }
 
-        uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+        uint64_t getSpecialField(SpecialField sfid, Opcode icode,
+                                 const InstMetaData::PtrType & meta = nullptr) const override
         {
+            (void) meta;
             switch (sfid)
             {
                 case SpecialField::AQ:
@@ -240,6 +245,8 @@ namespace mavis
                     throw UnsupportedExtractorSpecialFieldID("WD", icode);
                 case SpecialField::HINT:
                     throw UnsupportedExtractorSpecialFieldID("HINT", icode);
+                case SpecialField::STACK_ADJ:
+                    throw UnsupportedExtractorSpecialFieldID("STACK_ADJ", icode);
                 case SpecialField::__N:
                     throw InvalidExtractorSpecialFieldID("__N", icode);
             }

--- a/mavis/ExtractorDirectInfo.h
+++ b/mavis/ExtractorDirectInfo.h
@@ -129,7 +129,7 @@ namespace mavis
             }
         }
 
-        uint64_t getSpecialField(SpecialField, Opcode) const override
+        uint64_t getSpecialField(SpecialField, Opcode, const InstMetaData::PtrType &) const override
         {
             throw InvalidExtractorSpecialFieldID(mnemonic_);
         }

--- a/mavis/ExtractorTraceInfo.h
+++ b/mavis/ExtractorTraceInfo.h
@@ -172,7 +172,7 @@ namespace mavis
         // return icode;
         //}
 
-        uint64_t getSpecialField(SpecialField, Opcode) const override
+        uint64_t getSpecialField(SpecialField, Opcode, const InstMetaData::PtrType &) const override
         {
             throw InvalidExtractorSpecialFieldID(tinfo_.getMnemonic());
         }

--- a/mavis/ExtractorWrap.hpp
+++ b/mavis/ExtractorWrap.hpp
@@ -136,7 +136,7 @@ public:
         return obj_->getSignedOffset(icode);
     }
 
-    uint64_t getSpecialField(SpecialField sfid, Opcode icode) const override
+    uint64_t getSpecialField(SpecialField sfid, Opcode icode, const InstMetaData::PtrType &) const override
     {
         uint32_t index = form_->getSpecialFieldIndex(sfid);
         if (index == FormGeneric::INVALID_LIST_POS) {

--- a/mavis/OpcodeInfo.h
+++ b/mavis/OpcodeInfo.h
@@ -45,7 +45,6 @@ namespace mavis
         std::string dasmString() const
         {
             return dasm_->toString(getMnemonic(), icode_, meta_, extractor_);
-            // return extractor_->dasmString(getMnemonic(), icode_, meta_);
         }
 
         bool isHint() const { return info_->is_hint; }
@@ -282,7 +281,7 @@ namespace mavis
         {
             try
             {
-                return extractor_->getSpecialField(sfid, icode_);
+                return extractor_->getSpecialField(sfid, icode_, meta_);
             }
             catch (const UnsupportedExtractorSpecialFieldID & ex)
             {

--- a/test/basic/golden.out
+++ b/test/basic/golden.out
@@ -4908,6 +4908,6 @@ IFactoryMatchListComposite::Field family
 |	|	|	|	[default]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	[default]: 'csrrci', value=0x7073, extractor=Extractor 'CSRI', factory=IFactory('csr'), stencil = 0x1073
 line 1451: DASM: 0xb856 = cm.push	{x1, x8}, -32
-line 1468: DASM: 0xbe52 = cm.popret	{x1, x8}, 16
-line 1476: DASM: 0xa002 = cm.jt	0
-line 1484: DASM: 0xa082 = cm.jalt	32
+line 1469: DASM: 0xbe52 = cm.popret	{x1, x8}, 16
+line 1477: DASM: 0xa002 = cm.jt	0
+line 1485: DASM: 0xa082 = cm.jalt	32

--- a/test/basic/main.cpp
+++ b/test/basic/main.cpp
@@ -1451,6 +1451,7 @@ int main()
     cout << "line " << dec << __LINE__ << ": " << "DASM: 0xb856 = " << inst->dasmString() << endl;
     assert(inst->getMnemonic() == "cm.push");
     assert(inst->getIntDestRegs() == 0x4ull); // 1 dest
+    assert(inst->getSpecialField(mavis::OpcodeInfo::SpecialField::STACK_ADJ) == -32); // Should have stack_adj SF
 
     try
     {

--- a/test/directed/main.cpp
+++ b/test/directed/main.cpp
@@ -113,8 +113,6 @@ int main(int argc, char** argv)
 
     assert(nullptr != mavis_facade);
 
-    const auto inst_type_strings = mavis::InstMetaData::getInstructionTypeStrings();
-
     if (vm.count("opc"))
     {
         for (auto opcode : vm["opc"].as<std::vector<std::string>>())
@@ -147,11 +145,13 @@ int main(int argc, char** argv)
                 }
                 std::cout << "Inst type      : ";
                 std::string comma;
-                for (uint64_t inst_type = 0; inst_type < sizeof(mavis::InstMetaData::InstructionTypes) * 8; ++inst_type)
+                for (uint64_t inst_type = 0;
+                     inst_type < sizeof(mavis::InstMetaData::InstructionTypes) * 8;
+                     ++inst_type)
                 {
                     const auto itype = static_cast<mavis::InstMetaData::InstructionTypes>((0x1ull << inst_type));
                     if (inst->isInstType(itype)) {
-                        std::cout << comma << inst_type_strings.find(itype)->second;
+                        std::cout << comma << mavis::InstMetaData::getInstructionTypeName(itype);
                         comma = ", ";
                     }
                 }


### PR DESCRIPTION

- Created InstMetaData.cpp and moved a lot of code to that.  Sped up compilation quite a bit.
- Moved static maps/functions to source file; using boost::bitmap to allow for reverse lookups on enums.
- Added STACK_ADJ SpecialField which required the knowledge of meta data
- Ran clang-format