### PR TITLE
Fixed cm.mva01s and cm.mvsa01 dest/source lists

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "elfio"]
 	path = elfio
-	url = git@github.com:serge1/ELFIO.git
+	url = https://github.com/serge1/ELFIO.git

--- a/README.md
+++ b/README.md
@@ -4,9 +4,162 @@ Mavis is a framework that allows decoding of the RISC-V ISA into
 custom instruction class types as well as custom extensions to those
 class types.
 
-## Run regression
+Mavis is not a massive switch-case statement that most RISC-V decoders
+are.  Instead, Mavis intelligently builds a decode table or DTable
+with a digital tree or [Trie](https://en.wikipedia.org/wiki/Trie) to
+decode the instructions.
 
-Mavis is a header-only library. Regression needs to build a tester.
+## Basics of the Design
+
+Mavis' design is based on the notion there are two parts to every
+decoded instruction:
+
+1. Static information like instruction type, execution target units,
+   data width, etc.  This information is the same regardless of an
+   opcode's specifics.  For example, an `lw` is always loading 32-bits
+   of data regardless of the source/destionation registers
+
+1. Dynamic information like which registers are being sourced/written,
+   immediate field information, instruction modes, etc.
+
+On initialization of the Mavis decoder, Mavis instantiates the static
+information immediately for each instruction in the ISA.  The dynamic
+information is generated based on the specific opcode encountered.
+
+To instantiate the tree with static information, Mavis uses JSON files
+populated with instruction definitions to build the Trie at
+runtime.  Each instruction definition contains at minimum a stencil
+taht defines how that instruction is decoded:
+
+```
+ {
+    "mnemonic" : "amoxor.d",
+    "stencil" : "0x2000302f",
+    ...
+ }
+```
+
+The Trie is built using these stencils.  The data structure at each
+node of the tree is a factory or `IFactory` that Mavis uses to build
+the dynamic information or more specifically the modeler's instruction
+type.   This is what's returned to the user.
+
+The user can supply "micro-architectural" information to extend the
+instruction as it is being created using micro-architectural JSON files.
+
+Build the doxygen found in
+[mavis_docs](https://github.com/sparcians/mavis/tree/main/doc) to
+learn more.
+
+## Using Mavis
+
+### Build Mavis/Add to Project
+
+To add Mavis to a project, if using `cmake`, make Mavis a submodule or
+provide a local clone.  Then add the following to the project's CMakeLists.txt:
+
+```
+# Bring in the mavis project/CMakeLists.txt to build Mavis
+add_subdirectory (<path to mavis>)
+
+# Bring in the include path, no warnings from compilers
+include_directories (SYSTEM mavis)
+
+# Needed for Mavis to find the JSON files (to be changed by the user)
+file(CREATE_LINK <path to mavis>/json ${CMAKE_CURRENT_BINARY_DIR}/mavis_isa_files SYMBOLIC)
+
+# Link Mavis with project
+target_link_libraries(<project> mavis)
+```
+
+### Instantiating the Decoder
+
+Mavis needs class definitions for the Static Information and the
+Dynamic Information as described in [Basics of the Design](#Basics-of-the-Design).
+
+Example Static information class [uArchInfo](https://github.com/sparcians/mavis/blob/main/test/basic/uArchInfo.h)
+Example Dynamic information class [Instruction](https://github.com/sparcians/mavis/blob/main/test/basic/Inst.h)
+
+Mavis **requires** that the user classes (both Static and Dynamic classes) define a type called `PtrType`:
+
+```
+   class MyDynamicInstructionType
+   {
+   public:
+       typedef typename std::shared_ptr<MyDynamicinstructiontype> PtrType;
+       // ...
+   };
+```
+Mavis only keeps track of heap-allocated objects.  The
+allocation/deallocation of these objects can be managed/changed via
+the template parameters to Mavis.
+
+In addition, the constructor for the Dynamic instruction is required
+to take Mavis specific opcode information as well as the Static
+information created by the modeler.  This is how the Dynamic part of
+the instruction is connected to Mavis' detailed/static information
+Mavis.
+
+```
+   class MyDynamicInstructionType
+   {
+   public:
+       typedef typename std::shared_ptr<MyDynamicinstructiontype> PtrType;
+
+       MyDynamicInstructionType(const typename mavis::OpcodeInfo::PtrType & opcode_info,
+                                const typename MyStaticInstructionType::PtrType & new_ui,
+                                ... other construction arguments pass through by makeInst);
+
+   };
+```
+
+
+> **_NOTE_** Mavis' allocator works well with GNU allocators as well
+> as Sparta's
+> [SpartaSharedPointerAllocator](https://sparcians.github.io/map/classsparta_1_1SpartaSharedPointerAllocator.html)
+> class.
+
+Instantiate a Mavis instance:
+```
+#include "mavis/Mavis.h"
+
+#include "MyStaticInstructionType.hpp"
+#include "MyDynamicInstructionType.hpp"
+
+using MavisType = mavis::Mavis<MyDynamicinstructiontype, MyStaticInstructionType>;
+
+...
+
+{
+    // Create a mavis decoder that can only decode rv64imf
+    MavisType mavis_decoder({"json/isa_rv64i.json",
+                             "json/isa_rv64m.json",
+                             "json/isa_rv64f.json"},
+                             {"my_uarch_extensions_to_rv64imf.json"});
+
+    // Make add 1,2 3
+    MyDynamicInstructionType::PtrType inst = mavis_decoder.makeInst(0x003100b3,
+                               /* other construction info for MyDynamicInstructionType */);
+
+    // do stuff with the instruction
+}
+```
+
+### Using the Extension Manager
+
+The ExtensionManager is a power set of classes that allow the parsing
+of an ISA string and returning a Mavis instance that adheres to the
+given ISA.
+
+
+
+## Contributing
+
+### Run regression
+
+Regression is mostly manual and entails the developer to build a basic
+tester application, run it, and compare the output against a golden
+reference.
 
 * Build library, output will be `libmavis.a`
 ```

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ On initialization of the Mavis decoder, Mavis instantiates the static
 information immediately for each instruction in the ISA.  The dynamic
 information is generated based on the specific opcode encountered.
 
-To instantiate the tree with static information, Mavis uses JSON files
-populated with instruction definitions to build the Trie at
-runtime.  Each instruction definition contains at minimum a stencil
-taht defines how that instruction is decoded:
+To instantiate the tree with static information, Mavis uses [JSON
+files](https://github.com/sparcians/mavis/tree/main/json) populated
+with instruction definitions to build the Trie at runtime.  Each
+instruction definition contains at minimum a stencil that defines how
+that instruction is decoded:
 
 ```
  {
@@ -112,7 +113,7 @@ the instruction is connected to Mavis' detailed/static information.
        typedef typename std::shared_ptr<MyDynamicinstructiontype> PtrType;
 
        MyDynamicInstructionType(const typename mavis::OpcodeInfo::PtrType & opcode_info,
-                                const typename MyStaticInstructionType::PtrType & new_ui,
+                                const typename MyStaticInstructionType::PtrType & my_static_info,
                                 ... other construction arguments pass through by makeInst);
 
    };
@@ -134,7 +135,7 @@ using MavisType = mavis::Mavis<MyDynamicinstructiontype, MyStaticInstructionType
     MavisType mavis_decoder({"mavis_isa_files/isa_rv64i.json",
                              "mavis_isa_files/isa_rv64m.json",
                              "mavis_isa_files/isa_rv64f.json"},
-                             {"my_uarch_extensions_to_rv64imf.json"});
+                             {"my_uarch_extensions.json"});
 
     // Make add 1,2 3
     MyDynamicInstructionType::PtrType inst = mavis_decoder.makeInst(0x003100b3,
@@ -154,7 +155,7 @@ conflict with other extensions, the manager will throw an exception.
 Example:
 ```c++
 
-    const std::string rv_isa = "rv64imac_zicond_zicsr_zifencei_zawrs_zihintpause_zilsd_zabha_zacas_zfa";
+    const std::string rv_isa = "rv64imac_zicond_zicsr_zifencei_zawrs_zihintpause";
 
     mavis::extension_manager::riscv::RISCVExtensionManager extension_manager =
         mavis::extension_manager::riscv::RISCVExtensionManager::fromISA(
@@ -163,7 +164,7 @@ Example:
     std::unique_ptr<MavisType> mavis_decoder
         = std::make_unique<MavisType>(
             extension_manager.constructMavis<MyDynamicinstructiontype,
-                                             MyStaticinstructiontype>({"my_uarch_extensions_to_rv64imf.json"}));
+                                             MyStaticinstructiontype>({"my_uarch_extensions.json"}));
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Example Dynamic information class [Instruction](https://github.com/sparcians/mav
 
 Mavis **requires** that the user classes (both Static and Dynamic classes) define a type called `PtrType`:
 
-```
+```c++
    class MyDynamicInstructionType
    {
    public:
@@ -100,7 +100,7 @@ information created by the modeler.  This is how the Dynamic part of
 the instruction is connected to Mavis' detailed/static information
 Mavis.
 
-```
+```c++
    class MyDynamicInstructionType
    {
    public:
@@ -120,7 +120,7 @@ Mavis.
 > class.
 
 Instantiate a Mavis instance:
-```
+```c++
 #include "mavis/Mavis.h"
 
 #include "MyStaticInstructionType.hpp"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ class types.
 Mavis is not a massive switch-case statement that most RISC-V decoders
 are.  Instead, Mavis intelligently builds a decode table or DTable
 with a digital tree or [Trie](https://en.wikipedia.org/wiki/Trie) to
-decode the instructions.
+decode the instructions _at runtime_.
 
 ## Basics of the Design
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,6 @@ make
 ./mavis_decode --help
 ./mavis_decode -a rv32g -o 0x0001a283
 ./mavis_decode -a rv64g -o 0x0001b283
-./mavis_decode -a rv32gc -z -o 0x6008
-
 ```
 
 | RVA23U64 Mandatory Extensions | Status |

--- a/impl/forms/ExtractorDerived.h
+++ b/impl/forms/ExtractorDerived.h
@@ -2400,12 +2400,20 @@ namespace mavis
             if (meta->isAllOperandType(kind) || (kind == InstMetaData::OperandTypes::LONG)
                 || (kind == InstMetaData::OperandTypes::WORD))
             {
-                return getSourceRegs(icode);
+                return Extractor<Form_CMMV_mva01s>::getSourceRegs(icode);
             }
-            else
-            {
-                return 0;
-            }
+            return 0;
+        }
+
+        OperandInfo getDestOperandInfo(Opcode icode, const InstMetaData::PtrType & meta,
+                                       bool suppress_x0 = false) const override
+        {
+            const auto op_type = meta->getOperandType(InstMetaData::OperandFieldID::RD1);
+
+            OperandInfo olist;
+            olist.addElement(InstMetaData::OperandFieldID::RD1, op_type, 10, false);
+            olist.addElement(InstMetaData::OperandFieldID::RD2, op_type, 11, false);
+            return olist;
         }
 
         uint64_t getDestOperTypeRegs(const Opcode icode, const InstMetaData::PtrType & meta,
@@ -2414,23 +2422,20 @@ namespace mavis
             if (meta->isAllOperandType(kind) || (kind == InstMetaData::OperandTypes::LONG)
                 || (kind == InstMetaData::OperandTypes::WORD))
             {
-                return getDestRegs(icode);
+                return Extractor<Form_CMMV_mva01s>::getDestRegs(icode);
             }
-            else
-            {
-                return 0;
-            }
+            return 0;
         }
 
-        OperandInfo getDestOperandInfo(Opcode icode, const InstMetaData::PtrType & meta,
-                                       bool suppress_x0 = false) const override
+        OperandInfo getSourceOperandInfo(Opcode icode, const InstMetaData::PtrType & meta,
+                                         bool suppress_x0 = false) const override
         {
             OperandInfo olist;
             appendUnmaskedCompressedOperandInfo_(olist, icode, meta,
-                                                 InstMetaData::OperandFieldID::RD1,
+                                                 InstMetaData::OperandFieldID::RS1,
                                                  fixed_field_mask_, Form_CA::idType::RS1, false);
             appendUnmaskedCompressedOperandInfo_(olist, icode, meta,
-                                                 InstMetaData::OperandFieldID::RD2,
+                                                 InstMetaData::OperandFieldID::RS2,
                                                  fixed_field_mask_, Form_CA::idType::RS2, false);
             return olist;
         }

--- a/impl/forms/ExtractorDerived.h
+++ b/impl/forms/ExtractorDerived.h
@@ -2383,6 +2383,7 @@ namespace mavis
     template <> class Extractor<Form_CMMV_mva01s> : public Extractor<Form_CA>
     {
       public:
+
         uint64_t getSourceRegs(const Opcode icode) const override
         {
             return Extractor<Form_CA>::getSourceRegs(icode);
@@ -2473,6 +2474,14 @@ namespace mavis
     template <> class Extractor<Form_CMMV_mvsa01> : public Extractor<Form_CMMV_mva01s>
     {
       public:
+        bool isIllop(Opcode icode) const override
+        {
+            // Illegal if r1s` and r2s` are the same
+            const uint32_t r1s = extract_(Form_CA::idType::RS1, icode);
+            const uint32_t r2s = extract_(Form_CA::idType::RS2, icode);
+            return (r1s == r2s);
+        }
+
         uint64_t getSourceRegs(const Opcode icode) const override
         {
             return Extractor<Form_CMMV_mva01s>::getDestRegs(icode);

--- a/test/basic/golden.out
+++ b/test/basic/golden.out
@@ -3123,152 +3123,152 @@ IFactoryMatchListComposite::Field family
 |	|	|	[7]: IFactoryDenseComposite::Field func7
 |	|	|	|	[default]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	[default]: 'csrrci', value=0x7073, extractor=Extractor 'CSRI', factory=IFactory('csr'), stencil = 0x1073
-line 299: DASM: 0x9c61 = c.zext.b	x8,x8
-line 306: DASM: 0x9c69 = c.zext.h	x8,x8
-line 315: DASM: 0x9c71 = c.zext.w	x8,x8
-line 324: DASM: 0x0x60401013 = sext.b	x0,x0
-line 334: DASM: 0x003100b3 = add	x1,x2,x3
-line 340: DASM: 0x02028593 = addi	x11,x5, +0x20
-line 346: DASM: 0x00028593 = mv	x11,x5, +0x0
-line 348: Has Immediate? no
-line 354: DASM: 0x4081 = c.li	x1, x0, +0x0
-line 359: DASM: 0x000280e7 = jalr	x1,x5, +0x0
-line 369: DASM: 0xe152 = c.sdsp	x20, SP, IMM=128
-line 374: DASM: 0xfcd6 = c.sdsp	x21, SP, IMM=120
-line 379: DASM: 0xf1402573 = csrrs	x10,x0, CSR=0xf14
-line 385: DIRECT: 'add' = add	3,1,2
-line 390: DIRECT_BM: 'add' = add	3,1,2 0x0
-line 396: DIRECT: 'sw' = sw	2(D),1(A), 0x0
-line 401: DIRECT_BM: 'sw' = sw	 D:2, A:1 0x0
-line 407: DASM: 0x907405e3 = beq	x8,x7 +0xfffffffffffff90a
-line 409: Signed-offset: 0xfffffffffffff90a
-line 415: DASM: 0x107405e3 = beq	x8,x7 +0x90a
-line 417: Signed-offset: 0x90a
-line 423: DASM: 0xd3ad = c.beqz	x15, x0, +0xffffffffffffff62
-line 424: Signed-offset: 0xffffffffffffff62
-line 430: DASM: 0xc3ad = c.beqz	x15, x0, +0x62
-line 431: Signed-offset: 0x62
-line 437: DASM: 0x8f16c3ef = jal	x7, +0xfffffffffff6c8f0
-line 439: Signed-offset: 0xfffffffffff6c8f0
-line 445: DASM: 0x0f16c3ef = jal	x7, +0x6c8f0
-line 447: Signed-offset: 0x6c8f0
-line 453: DASM: 0xb555 = c.j	x0, +0xfffffffffffffea4
-line 454: Signed-offset: 0xfffffffffffffea4
-line 460: DASM: 0xa555 = c.j	x0, +0x6a4
-line 461: Signed-offset: 0x6a4
-line 467: DASM: 0xa9cc0767 = jalr	x14,x24, +0xfffffffffffffa9c
-line 469: Signed-offset: 0xfffffffffffffa9c
-line 475: DASM: 0xbe10afa3 = sw	x1,x1, +0xfffffffffffffbff
-line 477: A-Sources: 0000000000000000000000000000000000000000000000000000000000000010
-line 479: D-Sources: 0000000000000000000000000000000000000000000000000000000000000010
-line 483: Stencil for 'jalr' = 0x67
-line 487: DASM: 0x67 = jalr	x0,x0, +0x0
-line 493: DASM: 0x60e2 = c.ldsp	x1, SP, IMM=24
-line 494: A-Sources: 0000000000000000000000000000000000000000000000000000000000000100
-line 496: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 498: Has Immediate? YES
-line 504: DASM: 0x53007 = fld	f0,x10, +0x0
-line 505: A-Sources: 0000000000000000000000000000000000000000000000000000010000000000
-line 507: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 513: DASM: 0x2120 = c.fld	f8,x10, IMM=64
-line 514: A-Sources: 0000000000000000000000000000000000000000000000000000010000000000
-line 516: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 522: DASM: 0x30200073 = mret	
-line 524: A-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 526: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 532: DASM: 0x1000202f = lr.w	x0,x0, aq/wd=0, rl/vm=0
-line 534: A-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 536: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 542: DASM: 0x2928 = c.fld	f10,x10, IMM=80
-line 543: A-Sources: 0000000000000000000000000000000000000000000000000000010000000000
-line 545: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 547: Int-Sources: 0000000000000000000000000000000000000000000000000000010000000000
-line 549: Float-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 551: Int-Dests: 0000000000000000000000000000000000000000000000000000000000000000
-line 552: Float-Dests: 0000000000000000000000000000000000000000000000000000010000000000
-line 558: DASM: 0x2d2c = c.fld	f11,x10, IMM=88
-line 559: A-Sources: 0000000000000000000000000000000000000000000000000000010000000000
-line 561: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 563: Int-Sources: 0000000000000000000000000000000000000000000000000000010000000000
-line 565: Float-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 567: Int-Dests: 0000000000000000000000000000000000000000000000000000000000000000
-line 568: Float-Dests: 0000000000000000000000000000000000000000000000000000100000000000
-line 574: DASM: 0x72a7f543 = fmadd.d	f10,f15,f10,f14, RM=7
-line 576: fmadd.d RM field = 0x7
-line 583: DIRECT: 'fcvt.l.d' = fcvt.l.d	4,1
-line 594: DASM: 0x8006 = c.mv	x0, x1
-line 599: MORPH DASM: = cmov	4,1,2,3
-line 607: DASM (CANONICAL_NOP): = nop	x0,x0, +0x0
-line 614: DASM (C.NOP/CANONICAL_CNOP): = c.nop	+0x0
-line 622: DIRECT: 'feq.s' = feq.s	4,1,2
-line 628: DASM: 0x710d = c.addi16sp	x2,x2, +0xfffffffffffffea0
-line 633: DASM: 0x5769 = c.li	x14, x0, +0xfffffffffffffffa
-line 638: DASM: 0x7769 = c.lui	x14, +0xffffffffffffa000
-line 643: DASM: 0x177c = c.addi4spn	x15, SP, IMM=940
-line 648: DASM: 0x0063b2af = amoadd.d	x5,x7,x6, aq/wd=0, rl/vm=0
-line 654: DASM: 0x8516 = c.mv	x10, x5
-line 659: DASM: 0xe3c1 = c.bnez	x15, x0, +0x80
-line 664: DASM: 0x9696 = c.add	x13,x13,x5
-line 669: DASM: 0x5877857 = vsetvli	x16,x14, e64,m1,ta,mu
-line 675: DASM: 0x803170d7 = vsetvl	x1,x2,x3
-line 685: DASM: 0x2f007 = vle64.v	v0,x5,v0.t
-line 693: DASM: 0x102f007 = vle64ff.v	v0,x5,v0.t
-line 703: DASM: 0x202f007 = vle64.v	v0,x5
-line 712: DASM: 0x2206e007 = vlseg2e32.v	v0,x13
-line 721: DASM: 0xa606e007 = vluxseg6ei32.v	v0,x13,v0
-line 730: DASM: 0xea06e007 = vlsseg8e32.v	v0,x13,x0
-line 739: DASM: 0xc000007 = vloxei8.v	v0,x0,v0,v0.t
-line 747: DASM: 0x4000027 = vsuxei8.v	v0,x0,v0,v0.t
-line 754: DASM: 0x03ffbfd7 = vadd.vi	v31,v31,-1
-line 762: DASM: 0x3100D7 = vadd.vv	v1,v3,v2,v0.t
-line 783: OperandInfo field ID 'rs3' is invalid
-line 789: DASM: 0x403100D7 = vadc.vvm	v1,v2,v3
-line 798: DASM: 0x5E008157 = vmv.v.v	v2,v1
-line 806: DASM: 0x3140D7 = vadd.vx	v1,v3,x2,v0.t
-line 814: DASM: 0x403140D7 = vadc.vxm	v1,x2,v3
-line 823: DASM: 0x5E00C157 = vmv.v.x	v2,x1
-line 831: DASM: 9E2030D7 = vmv1r.v	v1,v2
-line 838: DASM: 5008A0D7 = vid.v	v1,v0.t
-line 845: DASM: 100a7 = vse8.v	v1,x2,v0.t
-line 853: DASM: 0xc6880857 = vwredsum.vs	v16,v8,v16
-line 859: DASM: 0x52a1b657 = vror.vi	v12,v10, IMM=3
-line 867: DASM: 0x56b43757 = vror.vi	v14,v11, IMM=40
-line 875: DASM: 0x56b43757 = vmacc.vv	v4,v5,v6
-line 903: DASM(Direct): = vsext.vf2	8,30
-line 922: DASM(DirectOpInfo): = vsext.vf2	8,30
-line 937: DASM: 0x53007 = c.fld	f8,x10, IMM=64
-line 938: A-Sources: 0000000000000000000000000000000000000000000000000000010000000000
-line 940: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 946: DASM: 0x40e2 = c.lwsp	x1, SP, IMM=24
-line 947: A-Sources: 0000000000000000000000000000000000000000000000000000000000000100
-line 949: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 951: Has Immediate? YES
-line 957: DASM: 0x60e2 = c.ldsp	x1, SP, IMM=24
-line 958: A-Sources: 0000000000000000000000000000000000000000000000000000000000000100
-line 960: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
-line 962: Has Immediate? YES
-line 968: DASM: 0x650d = c.lui	x10, +0x3000
-line 973: DASM: 0x12000073 = sfence.vma	x0,x0
-line 979: DASM: 0xa422 = c.fsdsp	f8, SP, IMM=8
-line 994: PSEUDO = P0	3,1,2, 0x0
-line 998: PSEUDO = P0	3,1,2
-line 1009: PSEUDO = P0	3,1,2 0xdead
-line 1020: PSEUDO = P1	2(D),1(A), 0x0
-line 1021: VM = 3
-line 1041: PSEUDO = P1	 D:2, A:1 0xbeef
-line 1058: PSEUDO = P0	3,1,2, 0x0
-line 1075: DASM: 0x6f8c = c.ld	x11,x15, IMM=24
-line 1079: DASM: 0x01043823 = sd	x16,x8, +0x10
-line 1091: DASM: 0x613 = li	x12, +0x0
-line 1096: DASM: 0x80000613 = li	x12, +0xfffffffffffff800
-line 1102: DASM: 0x13 = nop	x0,x0, +0x0
-line 1107: DASM: 0x8613 = mv	x12,x1, +0x0
-line 1112: DASM: 0x80008613 = addi	x12,x1, +0xfffffffffffff800
-line 1118: DASM: 0x6013 = prefetch.i	x0, +0x0
-line 1125: DASM: 0x6013 = ori	x0,x0, +0x2
-line 1132: DASM: 0x106013 = prefetch.r	x0, +0x0
-line 1139: DASM: 0x306013 = prefetch.w	x0, +0x1
-line 1146: DASM: 0x0100000f = pause	x0,x0, fm=0x0, pred=0x1, succ=0x0
+line 301: DASM: 0x9c61 = c.zext.b	x8,x8
+line 308: DASM: 0x9c69 = c.zext.h	x8,x8
+line 317: DASM: 0x9c71 = c.zext.w	x8,x8
+line 326: DASM: 0x0x60401013 = sext.b	x0,x0
+line 336: DASM: 0x003100b3 = add	x1,x2,x3
+line 342: DASM: 0x02028593 = addi	x11,x5, +0x20
+line 348: DASM: 0x00028593 = mv	x11,x5, +0x0
+line 350: Has Immediate? no
+line 356: DASM: 0x4081 = c.li	x1, x0, +0x0
+line 361: DASM: 0x000280e7 = jalr	x1,x5, +0x0
+line 371: DASM: 0xe152 = c.sdsp	x20, SP, IMM=128
+line 376: DASM: 0xfcd6 = c.sdsp	x21, SP, IMM=120
+line 381: DASM: 0xf1402573 = csrrs	x10,x0, CSR=0xf14
+line 387: DIRECT: 'add' = add	3,1,2
+line 392: DIRECT_BM: 'add' = add	3,1,2 0x0
+line 398: DIRECT: 'sw' = sw	2(D),1(A), 0x0
+line 403: DIRECT_BM: 'sw' = sw	 D:2, A:1 0x0
+line 409: DASM: 0x907405e3 = beq	x8,x7 +0xfffffffffffff90a
+line 411: Signed-offset: 0xfffffffffffff90a
+line 417: DASM: 0x107405e3 = beq	x8,x7 +0x90a
+line 419: Signed-offset: 0x90a
+line 425: DASM: 0xd3ad = c.beqz	x15, x0, +0xffffffffffffff62
+line 426: Signed-offset: 0xffffffffffffff62
+line 432: DASM: 0xc3ad = c.beqz	x15, x0, +0x62
+line 433: Signed-offset: 0x62
+line 439: DASM: 0x8f16c3ef = jal	x7, +0xfffffffffff6c8f0
+line 441: Signed-offset: 0xfffffffffff6c8f0
+line 447: DASM: 0x0f16c3ef = jal	x7, +0x6c8f0
+line 449: Signed-offset: 0x6c8f0
+line 455: DASM: 0xb555 = c.j	x0, +0xfffffffffffffea4
+line 456: Signed-offset: 0xfffffffffffffea4
+line 462: DASM: 0xa555 = c.j	x0, +0x6a4
+line 463: Signed-offset: 0x6a4
+line 469: DASM: 0xa9cc0767 = jalr	x14,x24, +0xfffffffffffffa9c
+line 471: Signed-offset: 0xfffffffffffffa9c
+line 477: DASM: 0xbe10afa3 = sw	x1,x1, +0xfffffffffffffbff
+line 479: A-Sources: 0000000000000000000000000000000000000000000000000000000000000010
+line 481: D-Sources: 0000000000000000000000000000000000000000000000000000000000000010
+line 485: Stencil for 'jalr' = 0x67
+line 489: DASM: 0x67 = jalr	x0,x0, +0x0
+line 495: DASM: 0x60e2 = c.ldsp	x1, SP, IMM=24
+line 496: A-Sources: 0000000000000000000000000000000000000000000000000000000000000100
+line 498: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 500: Has Immediate? YES
+line 506: DASM: 0x53007 = fld	f0,x10, +0x0
+line 507: A-Sources: 0000000000000000000000000000000000000000000000000000010000000000
+line 509: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 515: DASM: 0x2120 = c.fld	f8,x10, IMM=64
+line 516: A-Sources: 0000000000000000000000000000000000000000000000000000010000000000
+line 518: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 524: DASM: 0x30200073 = mret	
+line 526: A-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 528: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 534: DASM: 0x1000202f = lr.w	x0,x0, aq/wd=0, rl/vm=0
+line 536: A-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 538: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 544: DASM: 0x2928 = c.fld	f10,x10, IMM=80
+line 545: A-Sources: 0000000000000000000000000000000000000000000000000000010000000000
+line 547: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 549: Int-Sources: 0000000000000000000000000000000000000000000000000000010000000000
+line 551: Float-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 553: Int-Dests: 0000000000000000000000000000000000000000000000000000000000000000
+line 554: Float-Dests: 0000000000000000000000000000000000000000000000000000010000000000
+line 560: DASM: 0x2d2c = c.fld	f11,x10, IMM=88
+line 561: A-Sources: 0000000000000000000000000000000000000000000000000000010000000000
+line 563: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 565: Int-Sources: 0000000000000000000000000000000000000000000000000000010000000000
+line 567: Float-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 569: Int-Dests: 0000000000000000000000000000000000000000000000000000000000000000
+line 570: Float-Dests: 0000000000000000000000000000000000000000000000000000100000000000
+line 576: DASM: 0x72a7f543 = fmadd.d	f10,f15,f10,f14, RM=7
+line 578: fmadd.d RM field = 0x7
+line 585: DIRECT: 'fcvt.l.d' = fcvt.l.d	4,1
+line 596: DASM: 0x8006 = c.mv	x0, x1
+line 601: MORPH DASM: = cmov	4,1,2,3
+line 609: DASM (CANONICAL_NOP): = nop	x0,x0, +0x0
+line 616: DASM (C.NOP/CANONICAL_CNOP): = c.nop	+0x0
+line 624: DIRECT: 'feq.s' = feq.s	4,1,2
+line 630: DASM: 0x710d = c.addi16sp	x2,x2, +0xfffffffffffffea0
+line 635: DASM: 0x5769 = c.li	x14, x0, +0xfffffffffffffffa
+line 640: DASM: 0x7769 = c.lui	x14, +0xffffffffffffa000
+line 645: DASM: 0x177c = c.addi4spn	x15, SP, IMM=940
+line 650: DASM: 0x0063b2af = amoadd.d	x5,x7,x6, aq/wd=0, rl/vm=0
+line 656: DASM: 0x8516 = c.mv	x10, x5
+line 661: DASM: 0xe3c1 = c.bnez	x15, x0, +0x80
+line 666: DASM: 0x9696 = c.add	x13,x13,x5
+line 671: DASM: 0x5877857 = vsetvli	x16,x14, e64,m1,ta,mu
+line 677: DASM: 0x803170d7 = vsetvl	x1,x2,x3
+line 687: DASM: 0x2f007 = vle64.v	v0,x5,v0.t
+line 695: DASM: 0x102f007 = vle64ff.v	v0,x5,v0.t
+line 705: DASM: 0x202f007 = vle64.v	v0,x5
+line 714: DASM: 0x2206e007 = vlseg2e32.v	v0,x13
+line 723: DASM: 0xa606e007 = vluxseg6ei32.v	v0,x13,v0
+line 732: DASM: 0xea06e007 = vlsseg8e32.v	v0,x13,x0
+line 741: DASM: 0xc000007 = vloxei8.v	v0,x0,v0,v0.t
+line 749: DASM: 0x4000027 = vsuxei8.v	v0,x0,v0,v0.t
+line 756: DASM: 0x03ffbfd7 = vadd.vi	v31,v31,-1
+line 764: DASM: 0x3100D7 = vadd.vv	v1,v3,v2,v0.t
+line 785: OperandInfo field ID 'rs3' is invalid
+line 791: DASM: 0x403100D7 = vadc.vvm	v1,v2,v3
+line 800: DASM: 0x5E008157 = vmv.v.v	v2,v1
+line 808: DASM: 0x3140D7 = vadd.vx	v1,v3,x2,v0.t
+line 816: DASM: 0x403140D7 = vadc.vxm	v1,x2,v3
+line 825: DASM: 0x5E00C157 = vmv.v.x	v2,x1
+line 833: DASM: 9E2030D7 = vmv1r.v	v1,v2
+line 840: DASM: 5008A0D7 = vid.v	v1,v0.t
+line 847: DASM: 100a7 = vse8.v	v1,x2,v0.t
+line 855: DASM: 0xc6880857 = vwredsum.vs	v16,v8,v16
+line 861: DASM: 0x52a1b657 = vror.vi	v12,v10, IMM=3
+line 869: DASM: 0x56b43757 = vror.vi	v14,v11, IMM=40
+line 877: DASM: 0x56b43757 = vmacc.vv	v4,v5,v6
+line 905: DASM(Direct): = vsext.vf2	8,30
+line 924: DASM(DirectOpInfo): = vsext.vf2	8,30
+line 939: DASM: 0x53007 = c.fld	f8,x10, IMM=64
+line 940: A-Sources: 0000000000000000000000000000000000000000000000000000010000000000
+line 942: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 948: DASM: 0x40e2 = c.lwsp	x1, SP, IMM=24
+line 949: A-Sources: 0000000000000000000000000000000000000000000000000000000000000100
+line 951: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 953: Has Immediate? YES
+line 959: DASM: 0x60e2 = c.ldsp	x1, SP, IMM=24
+line 960: A-Sources: 0000000000000000000000000000000000000000000000000000000000000100
+line 962: D-Sources: 0000000000000000000000000000000000000000000000000000000000000000
+line 964: Has Immediate? YES
+line 970: DASM: 0x650d = c.lui	x10, +0x3000
+line 975: DASM: 0x12000073 = sfence.vma	x0,x0
+line 981: DASM: 0xa422 = c.fsdsp	f8, SP, IMM=8
+line 996: PSEUDO = P0	3,1,2, 0x0
+line 1000: PSEUDO = P0	3,1,2
+line 1011: PSEUDO = P0	3,1,2 0xdead
+line 1022: PSEUDO = P1	2(D),1(A), 0x0
+line 1023: VM = 3
+line 1043: PSEUDO = P1	 D:2, A:1 0xbeef
+line 1060: PSEUDO = P0	3,1,2, 0x0
+line 1077: DASM: 0x6f8c = c.ld	x11,x15, IMM=24
+line 1081: DASM: 0x01043823 = sd	x16,x8, +0x10
+line 1093: DASM: 0x613 = li	x12, +0x0
+line 1098: DASM: 0x80000613 = li	x12, +0xfffffffffffff800
+line 1104: DASM: 0x13 = nop	x0,x0, +0x0
+line 1109: DASM: 0x8613 = mv	x12,x1, +0x0
+line 1114: DASM: 0x80008613 = addi	x12,x1, +0xfffffffffffff800
+line 1120: DASM: 0x6013 = prefetch.i	x0, +0x0
+line 1127: DASM: 0x6013 = ori	x0,x0, +0x2
+line 1134: DASM: 0x106013 = prefetch.r	x0, +0x0
+line 1141: DASM: 0x306013 = prefetch.w	x0, +0x1
+line 1148: DASM: 0x0100000f = pause	x0,x0, fm=0x0, pred=0x1, succ=0x0
 ====== TAG 'pf' EXCLUDED =========
 IFactoryMatchListComposite::Field family
 |	[1]: IFactoryDenseComposite::Field opcode
@@ -3283,7 +3283,7 @@ IFactoryMatchListComposite::Field family
 |	|	|	[6]: IFactoryDenseComposite::Field func6
 |	|	|	|	[default]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	[default]: 'ori', value=0x6013, extractor=Extractor 'I', factory=IFactory('ori'), stencil = 0x6013
-line 1169: DASM: 0x6013 = ori	x0,x0, +0x0
+line 1171: DASM: 0x6013 = ori	x0,x0, +0x0
 ====== TAG 'ccf' EXCLUDED =========
 IFactoryMatchListComposite::Field family
 |	[1]: IFactoryDenseComposite::Field opcode
@@ -3291,7 +3291,7 @@ IFactoryMatchListComposite::Field family
 |	|	|	[6]: IFactoryDenseComposite::Field func6
 |	|	|	|	[default]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	[default]: 'ori', value=0x6013, extractor=Extractor 'I', factory=IFactory('ori'), stencil = 0x6013
-line 1186: DASM: 0x6013 = prefetch.i	x0, +0x0
+line 1188: DASM: 0x6013 = prefetch.i	x0, +0x0
 ====== TAG 'ccf' INCLUDED (ONLY) =========
 IFactoryMatchListComposite::Field family
 |	[1]: IFactoryDenseComposite::Field opcode
@@ -3302,9 +3302,9 @@ IFactoryMatchListComposite::Field family
 |	|	|	|	|	[1]: 'cbo.flush', mask=0x1f00f80, field_set=0x12, value=0x200000, nfixed=2, extractor=Extractor 'R', factory=IFactory('cbo.flush'), stencil = 0x20200f
 |	|	|	|	|	[2]: 'cbo.inval', mask=0x1f00f80, field_set=0x12, value=0x0, nfixed=2, extractor=Extractor 'R', factory=IFactory('cbo.inval'), stencil = 0x200f
 |	|	|	|	|	[3]: 'cbo.zero', mask=0x1f00f80, field_set=0x12, value=0x400000, nfixed=2, extractor=Extractor 'R', factory=IFactory('cbo.zero'), stencil = 0x40200f
-line 1208: DASM: 0x6013 fails to decode. This is expected
-line 1222: Missing ORI definition during build. This is expected
-line 1231: DASM: 0x6013 = prefetch.i	x0, +0x0
+line 1210: DASM: 0x6013 fails to decode. This is expected
+line 1224: Missing ORI definition during build. This is expected
+line 1233: DASM: 0x6013 = prefetch.i	x0, +0x0
 ====== TESTING RV32 =========
 IFactoryMatchListComposite::Field family
 |	[0]: IFactoryDenseComposite::Field opcode
@@ -3886,17 +3886,17 @@ IFactoryMatchListComposite::Field family
 |	|	|	[7]: IFactoryDenseComposite::Field func7
 |	|	|	|	[default]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	[default]: 'csrrci', value=0x7073, extractor=Extractor 'CSRI', factory=IFactory('csr'), stencil = 0x1073
-line 1265: DASM: 0x003100b3 = add	x1,x2,x3
-line 1272: DASM: 0x03103 = ld	x2,x0, +0x0
-line 1292: DASM: 0x006382af = amoadd.b	x5,x7,x6, aq/wd=0, rl/vm=0
-line 1298: DASM: 0x006392af = amoadd.h	x5,x7,x6, aq/wd=0, rl/vm=0
-line 1305: DASM: 0x2867322f = amocas.d	x4,x14,x6, aq/wd=0, rl/vm=0
-line 1311: DASM: 0x2863b22f = amocas.d	x4,x7,x6, aq/wd=0, rl/vm=0
-line 1327: DASM: 0x203023 = sd	x2,x0, +0x0
-line 1343: DASM: 0x2001 = c.jal	x1, +0x0
-line 1348: DASM: 0x4041d213 = srai	x4,x3, SHAMTW=4
-line 1354: DASM: 0x6008 = c.flw	f10,x8, IMM=0
-line 1360: DASM: 0xe008 = c.fsw	f10,x8, IMM=0
+line 1267: DASM: 0x003100b3 = add	x1,x2,x3
+line 1274: DASM: 0x03103 = ld	x2,x0, +0x0
+line 1294: DASM: 0x006382af = amoadd.b	x5,x7,x6, aq/wd=0, rl/vm=0
+line 1300: DASM: 0x006392af = amoadd.h	x5,x7,x6, aq/wd=0, rl/vm=0
+line 1307: DASM: 0x2867322f = amocas.d	x4,x14,x6, aq/wd=0, rl/vm=0
+line 1313: DASM: 0x2863b22f = amocas.d	x4,x7,x6, aq/wd=0, rl/vm=0
+line 1329: DASM: 0x203023 = sd	x2,x0, +0x0
+line 1345: DASM: 0x2001 = c.jal	x1, +0x0
+line 1350: DASM: 0x4041d213 = srai	x4,x3, SHAMTW=4
+line 1356: DASM: 0x6008 = c.flw	f10,x8, IMM=0
+line 1362: DASM: 0xe008 = c.fsw	f10,x8, IMM=0
 ====== TESTING RV32 Zclsd =========
 IFactoryMatchListComposite::Field family
 |	[0]: IFactoryDenseComposite::Field opcode
@@ -4315,8 +4315,8 @@ IFactoryMatchListComposite::Field family
 |	|	|	[7]: IFactoryDenseComposite::Field func7
 |	|	|	|	[default]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	[default]: 'csrrci', value=0x7073, extractor=Extractor 'CSRI', factory=IFactory('csr'), stencil = 0x1073
-line 1391: DASM: 0x6008 = c.ld	x10,x8, IMM=0
-line 1408: DASM: 0xe008 = c.sd	x10,x8, IMM=0
+line 1393: DASM: 0x6008 = c.ld	x10,x8, IMM=0
+line 1410: DASM: 0xe008 = c.sd	x10,x8, IMM=0
 ====== TESTING RV32 Zcmp/Zcmt =========
 IFactoryMatchListComposite::Field family
 |	[0]: IFactoryDenseComposite::Field opcode
@@ -4907,7 +4907,10 @@ IFactoryMatchListComposite::Field family
 |	|	|	[7]: IFactoryDenseComposite::Field func7
 |	|	|	|	[default]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	[default]: 'csrrci', value=0x7073, extractor=Extractor 'CSRI', factory=IFactory('csr'), stencil = 0x1073
-line 1451: DASM: 0xb856 = cm.push	{x1, x8}, -32
-line 1469: DASM: 0xbe52 = cm.popret	{x1, x8}, 16
-line 1477: DASM: 0xa002 = cm.jt	0
-line 1485: DASM: 0xa082 = cm.jalt	32
+line 1453: DASM: 0xb856 = cm.push	{x1, x8}, -32
+line 1471: DASM: 0xbe52 = cm.popret	{x1, x8}, 16
+line 1479: DASM: 0xa002 = cm.jt	0
+line 1487: DASM: 0xa082 = cm.jalt	32
+line 1498: DASM: 0xac22 is illegal 
+line 1502: DASM: 0xad26 = cm.mvsa01	x10,x9
+line 1504: DASM: 0xac62 = cm.mva01s	x8,x8

--- a/test/basic/main.cpp
+++ b/test/basic/main.cpp
@@ -1490,8 +1490,14 @@ int main()
     assert(inst->getImmediate() == 32ull);
 
     // These opcode variants have caused issues in the past
-    inst = mavis_facade_rv32.makeInst(0xac22, 0);
-    cout << "line " << dec << __LINE__ << ": " << "DASM: 0xac22 = " << inst->dasmString() << endl;
+    try {
+        inst = mavis_facade_rv32.makeInst(0xac22, 0);
+        assert(inst == nullptr);
+    }
+    catch (...) {
+        cout << "line " << dec << __LINE__ << ": DASM: 0xac22 is illegal " << endl;
+    }
+
     inst = mavis_facade_rv32.makeInst(0xad26, 0);
     cout << "line " << dec << __LINE__ << ": " << "DASM: 0xad26 = " << inst->dasmString() << endl;
     inst = mavis_facade_rv32.makeInst(0xac62, 0);

--- a/test/basic/main.cpp
+++ b/test/basic/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <bit>
 
 #include "mavis/Mavis.h"
 #include "mavis/MatchSet.hpp"
@@ -10,6 +11,7 @@
 #include "uArchInfo.h"
 
 using namespace std;
+
 
 struct ExampleTraceInfo
 {
@@ -1451,7 +1453,7 @@ int main()
     cout << "line " << dec << __LINE__ << ": " << "DASM: 0xb856 = " << inst->dasmString() << endl;
     assert(inst->getMnemonic() == "cm.push");
     assert(inst->getIntDestRegs() == 0x4ull); // 1 dest
-    assert(inst->getSpecialField(mavis::OpcodeInfo::SpecialField::STACK_ADJ) == -32); // Should have stack_adj SF
+    assert(std::bit_cast<int64_t>(inst->getSpecialField(mavis::OpcodeInfo::SpecialField::STACK_ADJ)) == -32); // Should have stack_adj SF
 
     try
     {
@@ -1486,6 +1488,14 @@ int main()
     assert(inst->getMnemonic() == "cm.jt");
     assert(inst->getIntDestRegs() == 0x2ull);
     assert(inst->getImmediate() == 32ull);
+
+    // These opcode variants have caused issues in the past
+    inst = mavis_facade_rv32.makeInst(0xac22, 0);
+    cout << "line " << dec << __LINE__ << ": " << "DASM: 0xac22 = " << inst->dasmString() << endl;
+    inst = mavis_facade_rv32.makeInst(0xad26, 0);
+    cout << "line " << dec << __LINE__ << ": " << "DASM: 0xad26 = " << inst->dasmString() << endl;
+    inst = mavis_facade_rv32.makeInst(0xac62, 0);
+    cout << "line " << dec << __LINE__ << ": " << "DASM: 0xac62 = " << inst->dasmString() << endl;
 
     return 0;
 }


### PR DESCRIPTION
@kathlenemagnus you mentioned that `cm.mvsa01` should be an illegal inst if rs1' == rs2'.  I added that.

```
$ ./mavis_decode -a rv32g_zce_zba_zbb_zbc_zbs_zcb_zicond_zicsr_zifencei_zawrs_zihintpause_zilsd_zabha_zacas_zfa stf_dump -o 0xac26
Dasm (0x000xac26): cm.mvsa01	x8,x9
  Addr-Sources : []: 0000000000000000000000000000000000000000000000000000000000000000
  Data-Sources : []: 0000000000000000000000000000000000000000000000000000000000000000
  Int-Sources  : [10-11]: 0000000000000000000000000000000000000000000000000000110000000000
  Float-Sources: []: 0000000000000000000000000000000000000000000000000000000000000000
  Int-Dests    : [8-9]: 0000000000000000000000000000000000000000000000000000001100000000
  Float-Dests  : []: 0000000000000000000000000000000000000000000000000000000000000000
Inst type      : int, arith, move
Src List: 
  Operand fid  : rs1
  Operand val  : 10
  Operand fid  : rs2
  Operand val  : 11
Dest List: 
  Operand fid  : rd
  Operand val  : 8
  Operand fid  : rd2
  Operand val  : 9
```
and
```
$ ./mavis_decode -a rv32g_zce_zba_zbb_zbc_zbs_zcb_zicond_zicsr_zifencei_zawrs_zihintpause_zilsd_zabha_zacas_zfa -o 0xac66
Dasm (0x000xac66): cm.mva01s	x8,x9
  Addr-Sources : []: 0000000000000000000000000000000000000000000000000000000000000000
  Data-Sources : []: 0000000000000000000000000000000000000000000000000000000000000000
  Int-Sources  : [8-9]: 0000000000000000000000000000000000000000000000000000001100000000
  Float-Sources: []: 0000000000000000000000000000000000000000000000000000000000000000
  Int-Dests    : [10-11]: 0000000000000000000000000000000000000000000000000000110000000000
  Float-Dests  : []: 0000000000000000000000000000000000000000000000000000000000000000
Inst type      : int, arith, move
Src List: 
  Operand fid  : rs1
  Operand val  : 8
  Operand fid  : rs2
  Operand val  : 9
Dest List: 
  Operand fid  : rd
  Operand val  : 10
  Operand fid  : rd2
  Operand val  : 11
```
and
```
$ ./mavis_decode -a rv32g_zce_zba_zbb_zbc_zbs_zcb_zicond_zicsr_zifencei_zawrs_zihintpause_zilsd_zabha_zacas_zfa stf_dump -o 0xac22
terminate called after throwing an instance of 'mavis::IllegalOpcode'
  what():  Opcode 0xac22 is illegal for instruction 'cm.mvsa01'
Aborted (core dumped)
```
closes #71 
closes #56 