### PR TITLE
Enable RV64 Support for Zabha

### DIFF
--- a/json/riscv_isa_spec.json
+++ b/json/riscv_isa_spec.json
@@ -524,7 +524,7 @@
       "json": "isa_rv64zvksh.json"
     },
     {
-      "xlen": 32,
+      "xlen": [32, 64],
       "extension": "zabha",
       "json": "isa_rv32zabha.json"
     },


### PR DESCRIPTION
The Zabha extension (byte and halfword atomics) is support in RV32 and RV64.