### PR TITLE
Include <typeindex> in ExtensionManager.hpp

### DIFF
--- a/mavis/ExtensionManager.hpp
+++ b/mavis/ExtensionManager.hpp
@@ -4,6 +4,7 @@
 #include <numeric>
 #include <set>
 #include <string>
+#include <typeindex>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
Fixes a compile error in the directed test.