### PR TITLE
Fixed Pause Instruction

### DIFF
--- a/json/isa_rv64zihintpause.json
+++ b/json/isa_rv64zihintpause.json
@@ -2,11 +2,8 @@
   {
     "mnemonic" : "pause",
     "tags" : ["zihintpause"],
-    "overlay" : {
-      "base" : "fence",
-      "match" : ["0xFFFF8F80", "0x01000000"]
-    },
     "form" : "FENCE",
+    "xform" : "I",
     "fixed" : ["rs1", "rd"],
     "stencil" : "0x0100000f",
     "type" : ["fence"]


### PR DESCRIPTION
For Pegasus, the pause instruction needs to be separated from the fence instructions because it has a different implementation.