### PR TITLE
Added Zvfh and Zvfhmin

### DIFF
--- a/json/riscv_isa_spec.json
+++ b/json/riscv_isa_spec.json
@@ -428,6 +428,17 @@
       "json": "isa_rv64zve64d.json"
     },
     {
+      "xlen": [32, 64],
+      "extension": "zvfh",
+      "requires": "zve32f",
+      "enables": "zvfhmin"
+    },
+    {
+      "xlen": [32, 64],
+      "extension": "zvfhmin",
+      "requires": "zve32f"
+    },
+    {
       "xlen": 64,
       "extension": "zaamo",
       "meta_extension": "a",


### PR DESCRIPTION
These extensions don't add any new instructions but allow the SEW to be set to 16 for vector FP instructions. Needed for Pegasus.