### PR TITLE
Allow using makeInstDirectly with overlay instructions, various Zicbop fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build
+debug
+release
 .cache
 clang-format-files.out
 

--- a/impl/forms/ExtractorDerived.h
+++ b/impl/forms/ExtractorDerived.h
@@ -3327,6 +3327,19 @@ namespace mavis
       public:
         Extractor() = default;
 
+        bool isIllop(Opcode icode) const override
+        {
+            // Form_I::idType::IMM corresponds to bits [31:20].
+            // Check the bottom 5 bits of this range to make sure it's a valid prefetch instruction.
+            static constexpr uint64_t MASK = std::numeric_limits<uint64_t>::max() >> 59;
+            const auto pref_op = extract_(Form_I::idType::IMM, icode) & MASK;
+
+            // 0 = prefetch.i
+            // 1 = prefetch.r
+            // 3 = prefetch.w
+            return !utils::isOneOf(pref_op, 0U, 1U, 3U);
+        }
+
         ExtractorIF::PtrType specialCaseClone(const uint64_t ffmask,
                                               const uint64_t fset) const override
         {
@@ -3388,7 +3401,11 @@ namespace mavis
 
         uint64_t getImmediate(const Opcode icode) const override
         {
-            return extract_(Form_I::idType::IMM, icode) >> 5;
+            // Form_I::idType::IMM corresponds to bits [31:20], but we want [31:25].
+            // The imm field in this form has bits [11:5].
+            // Therefore, we just need to zero out the bottom 5 Form_I::idType::IMM bits.
+            static constexpr uint64_t MASK = std::numeric_limits<uint64_t>::max() << 5;
+            return extract_(Form_I::idType::IMM, icode) & MASK;
         }
 
         int64_t getSignedOffset(const Opcode icode) const override

--- a/impl/forms/ExtractorForms.h
+++ b/impl/forms/ExtractorForms.h
@@ -285,7 +285,7 @@ namespace mavis
 
         // clang-format on
 
-      private:
+      protected:
         Extractor(const uint64_t ffmask, const uint64_t fset) : ExtractorBase(ffmask) {}
     };
 
@@ -1737,8 +1737,9 @@ namespace mavis
         {
             std::stringstream ss;
             ss << mnemonic << '\t';
-            formatRList_(ss, icode,
-                         [&ss](const uint64_t urlist) { ss << getRListRangeEnd_(urlist); });
+            formatRList_(ss, icode, [](std::stringstream& ss, const uint64_t urlist) {
+                ss << getRListRangeEnd_(urlist);
+            });
             ss << ", " << getSignedOffset(icode);
             return ss.str();
         }
@@ -1749,7 +1750,7 @@ namespace mavis
         {
             std::stringstream ss;
             ss << mnemonic << '\t';
-            formatRList_(ss, icode, [&ss, &meta, op_id = getFirstOperandID_()](const uint64_t urlist) mutable {
+            formatRList_(ss, icode, [&meta, op_id = getFirstOperandID_()](std::stringstream& ss, const uint64_t urlist) mutable {
                 ss << dasmFormatReg_(meta, op_id, getRListRangeEnd_(urlist));
                 op_id = incrementFieldID_(op_id);
             });
@@ -1804,7 +1805,7 @@ namespace mavis
 
                 const auto urlist_end = std::min(range.second, urlist);
 
-                format_func(urlist_begin);
+                format_func(ss, urlist_begin);
 
                 if (urlist_begin == urlist_end)
                 {
@@ -1813,7 +1814,7 @@ namespace mavis
 
                 ss << '-';
 
-                format_func(urlist_end);
+                format_func(ss, urlist_end);
             }
 
             ss << "}";
@@ -2598,7 +2599,7 @@ namespace mavis
                << "," << extract_(Form_ISH::idType::RS1, icode & ~fixed_field_mask_);
             if (!isMaskedField_(Form_ISH::idType::SHAMT, fixed_field_mask_))
             {
-                ss << ", SHAMT=" << std::dec << getImmediate(icode);
+                ss << ", " << getImmediateDasmName_() << "=" << std::dec << getImmediate(icode);
             }
             return ss.str();
         }
@@ -2614,15 +2615,18 @@ namespace mavis
                                       {Form_ISH::idType::RS1, InstMetaData::OperandFieldID::RS1}});
             if (!isMaskedField_(Form_ISH::idType::SHAMT, fixed_field_mask_))
             {
-                ss << ", SHAMT=" << std::dec << getImmediate(icode);
+                ss << ", " << getImmediateDasmName_() << "=" << std::dec << getImmediate(icode);
             }
             return ss.str();
         }
 
         // clang-format on
 
-      private:
+      protected:
         Extractor(const uint64_t ffmask, const uint64_t fset) : ExtractorBase(ffmask) {}
+
+      private:
+        virtual const char * getImmediateDasmName_() const { return "SHAMT"; }
     };
 
     /**

--- a/json/isa_rv64zicbop.json
+++ b/json/isa_rv64zicbop.json
@@ -24,8 +24,7 @@
     "fixed" : ["rd", "rs2"],
     "stencil" : "0x106013",
     "type" : ["prefetch", "hint"],
-    "l-oper" : ["rs1"],
-    "data" : 8
+    "l-oper" : ["rs1"]
   },
   {
     "mnemonic" : "prefetch.w",

--- a/mavis/ExtensionManager.hpp
+++ b/mavis/ExtensionManager.hpp
@@ -1350,7 +1350,7 @@ namespace mavis::extension_manager
         const UnknownExtensionAction unknown_extension_action_;
         std::string mavis_json_dir_;
         std::string isa_;
-	std::unordered_set<std::string> unknown_extensions_;
+        std::unordered_set<std::string> unknown_extensions_;
         using ArchMap = std::unordered_map<uint32_t, ExtensionState>;
         ArchMap extensions_;
         typename ArchMap::iterator enabled_arch_{extensions_.end()};
@@ -1798,7 +1798,7 @@ namespace mavis::extension_manager
         ExtensionManager(ExtensionManager &&) = default;
         virtual ~ExtensionManager() = default;
 
-        const std::unordered_set<std::string> getUnknownExtensions() const
+        const std::unordered_set<std::string>& getUnknownExtensions() const
         {
             return unknown_extensions_;
         }

--- a/mavis/IFactory.h
+++ b/mavis/IFactory.h
@@ -1274,6 +1274,10 @@ namespace mavis
                     if (olay->getExtractor() != nullptr)
                     {
                         use_extractor = olay->getExtractor();
+                        if (use_extractor->isIllop(icode))
+                        {
+                            throw IllegalOpcode(use_mnemonic, icode);
+                        }
                     }
                     use_meta = olay->getMetaData();
                     use_dasm = olay->getDasm();
@@ -1312,12 +1316,13 @@ namespace mavis
         typename IFactoryIF<InstType, AnnotationType>::IFactoryInfo::PtrType
         getInfoBypassCache(const std::string & mnemonic, const ExtractorIF::PtrType & extractor)
         {
-            // TODO: Overlays are not supported yet, since no opcode provided
+            const auto meta = getMeta_(mnemonic);
+
             const DecodedInstructionInfo::PtrType & new_dii =
                 std::make_shared<DecodedInstructionInfo>(mnemonic, getInstructionUID_(mnemonic),
-                                                         extractor, meta_, Opcode(0));
+                                                         extractor, meta, Opcode(0));
             OpcodeInfo::PtrType optr =
-                std::make_shared<OpcodeInfo>(Opcode(0), new_dii, extractor, meta_, dasm_);
+                std::make_shared<OpcodeInfo>(Opcode(0), new_dii, extractor, meta, dasm_);
 
             // return std::make_shared<typename IFactoryIF<InstType,
             // AnnotationType>::IFactoryInfo>(optr, getAnnotation_(mnemonic));
@@ -1370,11 +1375,16 @@ namespace mavis
             // Clone the factory metadata and merge in the new stuff
             InstMetaData::PtrType combined_meta = meta_->clone();
             combined_meta->merge(new_meta);
+            registerInstructionVariantMetaData(mnemonic, combined_meta);
+        }
 
+        void registerInstructionVariantMetaData(const std::string & mnemonic,
+                                                const InstMetaData::PtrType & new_meta)
+        {
             // Register the combined metadata with the mnemonic
             if (meta_map_.find(mnemonic) == meta_map_.end())
             {
-                meta_map_[mnemonic] = combined_meta;
+                meta_map_[mnemonic] = new_meta;
             }
             else
             {

--- a/mavis/IFactoryBuilder.h
+++ b/mavis/IFactoryBuilder.h
@@ -210,6 +210,25 @@ namespace mavis
                 throw BuildErrorOverlayMissingAnnotation(olay_mnemonic, olay_base_mnemonic);
             }
             olay->setAnnotation(panno);
+
+            // Only register the overlay manually if it doesn't already have a factory registered, i.e.
+            // it has a custom IFactory
+            if(auto olay_ifact = this->findIFact(olay_mnemonic); olay_ifact == nullptr)
+            {
+                // Register the overlay mnemonic with the IFactory so that
+                // we can use makeInstDirectly with a mnemonic
+                auto ifact = this->findIFact(olay_base_mnemonic);
+
+                if (ifact == nullptr)
+                {
+                    throw BuildErrorOverlayBaseNotFound(olay_mnemonic, olay_base_mnemonic, jfile);
+                }
+
+                ifact->addInstructionVariantUID(olay_mnemonic, olay->getUID());
+                ifact->registerInstructionVariantMetaData(olay_mnemonic, olay->getMetaData());
+                ifact->addInstructionVariantAnnotation(olay_mnemonic, panno);
+                registry_[olay_mnemonic] = std::move(ifact);
+            }
         }
     };
 

--- a/mavis/InstMetaData.h
+++ b/mavis/InstMetaData.h
@@ -320,7 +320,7 @@ namespace mavis
             }
         }
 
-        static const std::string &  getInstructionTypeName(const InstructionTypes & inst_type);
+        static const std::string & getInstructionTypeName(const InstructionTypes & inst_type);
 
         template <typename... ArgTypes> void setInstType(const ArgTypes &&... args)
         {

--- a/mavis/extension_managers/RISCVExtensionManager.hpp
+++ b/mavis/extension_managers/RISCVExtensionManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include "elfio/elfio.hpp"
 #include "mavis/ExtensionManager.hpp"
 #include "mavis/Utils.h"

--- a/test/basic/golden.out
+++ b/test/basic/golden.out
@@ -3486,8 +3486,10 @@ line 1153: DASM: 0x80008613 = addi	x12,x1, +0xfffffffffffff800
 line 1159: DASM: 0x6013 = prefetch.i	x0, +0x0
 line 1166: DASM: 0x6013 = ori	x0,x0, +0x2
 line 1173: DASM: 0x106013 = prefetch.r	x0, +0x0
-line 1180: DASM: 0x306013 = prefetch.w	x0, +0x1
-line 1187: DASM: 0x0100000f = pause	, +0x10
+line 1186: DASM: 0x3106013 fails to decode. This is expected
+line 1193: DASM: 0x8106013 = prefetch.r	x0, +0xffffffffffffff80
+line 1200: DASM: 0x2306013 = prefetch.w	x0, +0x20
+line 1207: DASM: 0x0100000f = pause	, +0x10
 ====== TAG 'pf' EXCLUDED =========
 IFactoryMatchListComposite::Field family
 |	[1]: IFactoryDenseComposite::Field opcode
@@ -3505,7 +3507,7 @@ IFactoryMatchListComposite::Field family
 |	|	|	|	[0]: IFactoryDenseComposite::Field func4
 |	|	|	|	|	[0]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	|	[default]: 'ori', value=0x6013, extractor=Extractor 'I', factory=IFactory('ori'), stencil = 0x6013
-line 1210: DASM: 0x6013 = ori	x0,x0, +0x0
+line 1230: DASM: 0x6013 = ori	x0,x0, +0x0
 ====== TAG 'ccf' EXCLUDED =========
 IFactoryMatchListComposite::Field family
 |	[1]: IFactoryDenseComposite::Field opcode
@@ -3514,7 +3516,7 @@ IFactoryMatchListComposite::Field family
 |	|	|	|	[0]: IFactoryDenseComposite::Field func4
 |	|	|	|	|	[0]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	|	[default]: 'ori', value=0x6013, extractor=Extractor 'I', factory=IFactory('ori'), stencil = 0x6013
-line 1227: DASM: 0x6013 = prefetch.i	x0, +0x0
+line 1247: DASM: 0x6013 = prefetch.i	x0, +0x0
 ====== TAG 'ccf' INCLUDED (ONLY) =========
 IFactoryMatchListComposite::Field family
 |	[1]: IFactoryDenseComposite::Field opcode
@@ -3527,59 +3529,59 @@ IFactoryMatchListComposite::Field family
 |	|	|	|	|	|	|	[1]: 'cbo.flush', mask=0x1f00f80, field_set=0x48, value=0x200000, nfixed=2, extractor=Extractor 'R', factory=IFactory('cbo.flush'), stencil = 0x20200f
 |	|	|	|	|	|	|	[2]: 'cbo.inval', mask=0x1f00f80, field_set=0x48, value=0x0, nfixed=2, extractor=Extractor 'R', factory=IFactory('cbo.inval'), stencil = 0x200f
 |	|	|	|	|	|	|	[3]: 'cbo.zero', mask=0x1f00f80, field_set=0x48, value=0x400000, nfixed=2, extractor=Extractor 'R', factory=IFactory('cbo.zero'), stencil = 0x40200f
-line 1249: DASM: 0x6013 fails to decode. This is expected
-line 1263: Missing ORI definition during build. This is expected
-line 1272: DASM: 0x6013 = prefetch.i	x0, +0x0
+line 1269: DASM: 0x6013 fails to decode. This is expected
+line 1283: Missing ORI definition during build. This is expected
+line 1292: DASM: 0x6013 = prefetch.i	x0, +0x0
 ====== TESTING MOP, CMOP, and zicfiss =========
-line 1296: DASM: 0x81c04073 = mop.r.0	x0
-line 1296: DASM: 0x81d04073 = mop.r.1	x0
-line 1296: DASM: 0x81e04073 = mop.r.2	x0
-line 1296: DASM: 0x81f04073 = mop.r.3	x0
-line 1296: DASM: 0x85c04073 = mop.r.4	x0
-line 1296: DASM: 0x85d04073 = mop.r.5	x0
-line 1296: DASM: 0x85e04073 = mop.r.6	x0
-line 1296: DASM: 0x85f04073 = mop.r.7	x0
-line 1296: DASM: 0x89c04073 = mop.r.8	x0
-line 1296: DASM: 0x89d04073 = mop.r.9	x0
-line 1296: DASM: 0x89e04073 = mop.r.10	x0
-line 1296: DASM: 0x89f04073 = mop.r.11	x0
-line 1296: DASM: 0x8dc04073 = mop.r.12	x0
-line 1296: DASM: 0x8dd04073 = mop.r.13	x0
-line 1296: DASM: 0x8de04073 = mop.r.14	x0
-line 1296: DASM: 0x8df04073 = mop.r.15	x0
-line 1296: DASM: 0xc1c04073 = mop.r.16	x0
-line 1296: DASM: 0xc1d04073 = mop.r.17	x0
-line 1296: DASM: 0xc1e04073 = mop.r.18	x0
-line 1296: DASM: 0xc1f04073 = mop.r.19	x0
-line 1296: DASM: 0xc5c04073 = mop.r.20	x0
-line 1296: DASM: 0xc5d04073 = mop.r.21	x0
-line 1296: DASM: 0xc5e04073 = mop.r.22	x0
-line 1296: DASM: 0xc5f04073 = mop.r.23	x0
-line 1296: DASM: 0xc9c04073 = mop.r.24	x0
-line 1296: DASM: 0xc9d04073 = mop.r.25	x0
-line 1296: DASM: 0xc9e04073 = mop.r.26	x0
-line 1296: DASM: 0xc9f04073 = mop.r.27	x0
-line 1296: DASM: 0xcdc04073 = mop.r.28	x0
-line 1296: DASM: 0xcdd04073 = mop.r.29	x0
-line 1296: DASM: 0xcde04073 = mop.r.30	x0
-line 1296: DASM: 0xcdf04073 = mop.r.31	x0
-line 1316: DASM: 0x6081 = c.mop.1
-line 1316: DASM: 0x6181 = c.mop.3
-line 1316: DASM: 0x6281 = c.mop.5
-line 1316: DASM: 0x6381 = c.mop.7
-line 1316: DASM: 0x6481 = c.mop.9
-line 1316: DASM: 0x6581 = c.mop.11
-line 1316: DASM: 0x6681 = c.mop.13
-line 1316: DASM: 0x6781 = c.mop.15
-line 1337: DASM: 0xce104073 = sspush	x1
-line 1343: DASM: 0xce504073 = sspush	x5
-line 1349: DASM: 0xcdc0c073 = sspopchk	x1
-line 1355: DASM: 0xcdc2c073 = sspopchk	x5
-line 1361: DASM: 0xcdc54173 = ssrdp	x2
-line 1367: DASM: 0x4800202f = ssamoswap.w	x0,x0,x0, aq/wd=0, rl/vm=0
-line 1373: DASM: 0x4800302f = ssamoswap.d	x0,x0,x0, aq/wd=0, rl/vm=0
-line 1401: DASM: 0x6081 = c.sspush
-line 1406: DASM: 0x6281 = c.sspopchk
+line 1316: DASM: 0x81c04073 = mop.r.0	x0
+line 1316: DASM: 0x81d04073 = mop.r.1	x0
+line 1316: DASM: 0x81e04073 = mop.r.2	x0
+line 1316: DASM: 0x81f04073 = mop.r.3	x0
+line 1316: DASM: 0x85c04073 = mop.r.4	x0
+line 1316: DASM: 0x85d04073 = mop.r.5	x0
+line 1316: DASM: 0x85e04073 = mop.r.6	x0
+line 1316: DASM: 0x85f04073 = mop.r.7	x0
+line 1316: DASM: 0x89c04073 = mop.r.8	x0
+line 1316: DASM: 0x89d04073 = mop.r.9	x0
+line 1316: DASM: 0x89e04073 = mop.r.10	x0
+line 1316: DASM: 0x89f04073 = mop.r.11	x0
+line 1316: DASM: 0x8dc04073 = mop.r.12	x0
+line 1316: DASM: 0x8dd04073 = mop.r.13	x0
+line 1316: DASM: 0x8de04073 = mop.r.14	x0
+line 1316: DASM: 0x8df04073 = mop.r.15	x0
+line 1316: DASM: 0xc1c04073 = mop.r.16	x0
+line 1316: DASM: 0xc1d04073 = mop.r.17	x0
+line 1316: DASM: 0xc1e04073 = mop.r.18	x0
+line 1316: DASM: 0xc1f04073 = mop.r.19	x0
+line 1316: DASM: 0xc5c04073 = mop.r.20	x0
+line 1316: DASM: 0xc5d04073 = mop.r.21	x0
+line 1316: DASM: 0xc5e04073 = mop.r.22	x0
+line 1316: DASM: 0xc5f04073 = mop.r.23	x0
+line 1316: DASM: 0xc9c04073 = mop.r.24	x0
+line 1316: DASM: 0xc9d04073 = mop.r.25	x0
+line 1316: DASM: 0xc9e04073 = mop.r.26	x0
+line 1316: DASM: 0xc9f04073 = mop.r.27	x0
+line 1316: DASM: 0xcdc04073 = mop.r.28	x0
+line 1316: DASM: 0xcdd04073 = mop.r.29	x0
+line 1316: DASM: 0xcde04073 = mop.r.30	x0
+line 1316: DASM: 0xcdf04073 = mop.r.31	x0
+line 1336: DASM: 0x6081 = c.mop.1
+line 1336: DASM: 0x6181 = c.mop.3
+line 1336: DASM: 0x6281 = c.mop.5
+line 1336: DASM: 0x6381 = c.mop.7
+line 1336: DASM: 0x6481 = c.mop.9
+line 1336: DASM: 0x6581 = c.mop.11
+line 1336: DASM: 0x6681 = c.mop.13
+line 1336: DASM: 0x6781 = c.mop.15
+line 1357: DASM: 0xce104073 = sspush	x1
+line 1363: DASM: 0xce504073 = sspush	x5
+line 1369: DASM: 0xcdc0c073 = sspopchk	x1
+line 1375: DASM: 0xcdc2c073 = sspopchk	x5
+line 1381: DASM: 0xcdc54173 = ssrdp	x2
+line 1387: DASM: 0x4800202f = ssamoswap.w	x0,x0,x0, aq/wd=0, rl/vm=0
+line 1393: DASM: 0x4800302f = ssamoswap.d	x0,x0,x0, aq/wd=0, rl/vm=0
+line 1421: DASM: 0x6081 = c.sspush
+line 1426: DASM: 0x6281 = c.sspopchk
 ====== TESTING RV32 =========
 IFactoryMatchListComposite::Field family
 |	[0]: IFactoryDenseComposite::Field opcode
@@ -4280,17 +4282,17 @@ IFactoryMatchListComposite::Field family
 |	|	|	|	|	[default]: IFactoryDenseComposite::Field func1
 |	|	|	|	|	|	[default]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	|	|	[default]: 'csrrci', value=0x7073, extractor=Extractor 'CSRI', factory=IFactory('csr'), stencil = 0x1073
-line 1440: DASM: 0x003100b3 = add	x1,x2,x3
-line 1447: DASM: 0x03103 = ld	x2,x0, +0x0
-line 1467: DASM: 0x006382af = amoadd.b	x5,x7,x6, aq/wd=0, rl/vm=0
-line 1473: DASM: 0x006392af = amoadd.h	x5,x7,x6, aq/wd=0, rl/vm=0
-line 1480: DASM: 0x2867322f = amocas.d	x4,x14,x6, aq/wd=0, rl/vm=0
-line 1486: DASM: 0x2863b22f = amocas.d	x4,x7,x6, aq/wd=0, rl/vm=0
-line 1502: DASM: 0x203023 = sd	x2,x0, +0x0
-line 1518: DASM: 0x2001 = c.jal	x1, +0x0
-line 1523: DASM: 0x4041d213 = srai	x4,x3, SHAMTW=4
-line 1529: DASM: 0x6008 = c.flw	f10,x8, IMM=0
-line 1535: DASM: 0xe008 = c.fsw	f10,x8, IMM=0
+line 1460: DASM: 0x003100b3 = add	x1,x2,x3
+line 1467: DASM: 0x03103 = ld	x2,x0, +0x0
+line 1487: DASM: 0x006382af = amoadd.b	x5,x7,x6, aq/wd=0, rl/vm=0
+line 1493: DASM: 0x006392af = amoadd.h	x5,x7,x6, aq/wd=0, rl/vm=0
+line 1500: DASM: 0x2867322f = amocas.d	x4,x14,x6, aq/wd=0, rl/vm=0
+line 1506: DASM: 0x2863b22f = amocas.d	x4,x7,x6, aq/wd=0, rl/vm=0
+line 1522: DASM: 0x203023 = sd	x2,x0, +0x0
+line 1538: DASM: 0x2001 = c.jal	x1, +0x0
+line 1543: DASM: 0x4041d213 = srai	x4,x3, SHAMTW=4
+line 1549: DASM: 0x6008 = c.flw	f10,x8, IMM=0
+line 1555: DASM: 0xe008 = c.fsw	f10,x8, IMM=0
 ====== TESTING RV32 Zclsd =========
 IFactoryMatchListComposite::Field family
 |	[0]: IFactoryDenseComposite::Field opcode
@@ -4771,8 +4773,8 @@ IFactoryMatchListComposite::Field family
 |	|	|	|	|	[default]: IFactoryDenseComposite::Field func1
 |	|	|	|	|	|	[default]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	|	|	[default]: 'csrrci', value=0x7073, extractor=Extractor 'CSRI', factory=IFactory('csr'), stencil = 0x1073
-line 1570: DASM: 0x6008 = c.ld	x10,x8, IMM=0
-line 1587: DASM: 0xe008 = c.sd	x10,x8, IMM=0
+line 1590: DASM: 0x6008 = c.ld	x10,x8, IMM=0
+line 1607: DASM: 0xe008 = c.sd	x10,x8, IMM=0
 ====== TESTING RV32 Zcmp/Zcmt =========
 IFactoryMatchListComposite::Field family
 |	[0]: IFactoryDenseComposite::Field opcode
@@ -5426,10 +5428,10 @@ IFactoryMatchListComposite::Field family
 |	|	|	|	|	[default]: IFactoryDenseComposite::Field func1
 |	|	|	|	|	|	[default]: IFactorySpecialCaseComposite::Field 
 |	|	|	|	|	|	|	[default]: 'csrrci', value=0x7073, extractor=Extractor 'CSRI', factory=IFactory('csr'), stencil = 0x1073
-line 1630: DASM: 0xb856 = cm.push	{x1, x8}, -32
-line 1648: DASM: 0xbe52 = cm.popret	{x1, x8}, 16
-line 1656: DASM: 0xa002 = cm.jt	0
-line 1664: DASM: 0xa082 = cm.jalt	32
-line 1675: DASM: 0xac22 is illegal 
-line 1680: DASM: 0xad26 = cm.mvsa01	x18,x9
-line 1682: DASM: 0xac62 = cm.mva01s	x8,x8
+line 1650: DASM: 0xb856 = cm.push	{x1, x8}, -32
+line 1668: DASM: 0xbe52 = cm.popret	{x1, x8}, 16
+line 1676: DASM: 0xa002 = cm.jt	0
+line 1684: DASM: 0xa082 = cm.jalt	32
+line 1695: DASM: 0xac22 is illegal 
+line 1700: DASM: 0xad26 = cm.mvsa01	x18,x9
+line 1702: DASM: 0xac62 = cm.mva01s	x8,x8

--- a/test/basic/main.cpp
+++ b/test/basic/main.cpp
@@ -1174,11 +1174,31 @@ int main()
     ASSERT_ALWAYS(inst->getImmediate() == 0);
     ASSERT_ALWAYS(inst->hasImmediate() == true);
 
-    // prefetch.w x0, 0x1
+    try
+    {
+        // prefetch.r x0, 0x30
+        // This is an invalid immediate and should fail to decode
+        inst = mavis_facade.makeInst(0x3106013, 0);
+        ASSERT_ALWAYS(inst == nullptr);
+    }
+    catch (const mavis::IllegalOpcode &)
+    {
+        cout << "line " << dec << __LINE__ << ": "
+             << "DASM: 0x3106013 fails to decode. This is expected" << endl;
+    }
+
+    // prefetch.r x0, 0x80
+    inst = mavis_facade.makeInst(0x8106013, 0);
+    ASSERT_ALWAYS(inst != nullptr);
+    cout << "line " << dec << __LINE__ << ": " << "DASM: 0x8106013 = " << inst->dasmString() << endl;
+    ASSERT_ALWAYS(inst->getImmediate() == 0x80);
+    ASSERT_ALWAYS(inst->hasImmediate() == true);
+
+    // prefetch.w x0, 0x20
     inst = mavis_facade.makeInst(0x2306013, 0);
     ASSERT_ALWAYS(inst != nullptr);
-    cout << "line " << dec << __LINE__ << ": " << "DASM: 0x306013 = " << inst->dasmString() << endl;
-    ASSERT_ALWAYS(inst->getImmediate() == 1);
+    cout << "line " << dec << __LINE__ << ": " << "DASM: 0x2306013 = " << inst->dasmString() << endl;
+    ASSERT_ALWAYS(inst->getImmediate() == 32);
     ASSERT_ALWAYS(inst->hasImmediate() == true);
 
     // pause


### PR DESCRIPTION
* Allow using makeInstDirectly with overlay mnemonics Fix prefetch immediate shift and data size
* Check overlays for illegal opcodes
* Add isIllop override for PF_hint
* Add test for `prefetch.r` immediate encoding and illegal encoding